### PR TITLE
Prevent unnecessary rebuilds of idalib-sys

### DIFF
--- a/idalib-sys/build.rs
+++ b/idalib-sys/build.rs
@@ -46,7 +46,10 @@ fn main() {
             continue;
         }
 
-        fs::copy(header.path(), ida.join(header.file_name())).unwrap();
+        let target = ida.join(header.file_name());
+        if fs::read(&target).ok() != fs::read(header.path()).ok() {
+            fs::copy(header.path(), target).unwrap();
+        }
     }
 
     let ffi_path = PathBuf::from("src");


### PR DESCRIPTION
Previously every build would invoke the build script which would overwrite the copied header files. This then lead to cargo detecting a change in those files and marking the crate as dirty leading to recompilation.

Now we don't overwrite the files anymore if there were no changes. Unfortunately this still results in one needless recompilation after the first clean compilation. But after that none occur anymore.

Alternative solutions:
- Don't copy the header files anymore. I guess the idea was to make the `#include`s cleaner but not sure if that's worth it if it makes the build more complicated.
- Somehow prevent `cxx_build` (who I believe is the culprit?) from emitting the `rerun-if-changed=asd.h` lines so overwriting the headers doesn't matter anymore. But we still want it for the other source files which are not copied from the IDA SDK.