### PR TITLE
Reduce noise from idalib

### DIFF
--- a/idalib-sys/src/kernwin_extras.h
+++ b/idalib-sys/src/kernwin_extras.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "pro.h"
+#include "kernwin.hpp"
+#include "auto.hpp"
+
+int open_database_quiet(const char *name, bool auto_analysis) {
+  auto new_file = 0;
+  const char *argv[] = { "idalib", name };
+  auto result = init_database(2, argv, &new_file);
+
+  if (result != 0) {
+    return result;
+  }
+
+  (*callui)(ui_notification_t::ui_ready_to_run);
+
+  if (auto_analysis) {
+    result = !auto_wait();
+  }
+
+  return result;
+}

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -37,6 +37,7 @@ include_cpp! {
     // NOTE: this fixes autocxx's inability to detect ea_t, optype_t as POD...
     #include "types.h"
 
+    #include "auto.hpp"
     #include "bytes.hpp"
     #include "entry.hpp"
     #include "funcs.hpp"
@@ -49,6 +50,7 @@ include_cpp! {
     #include "ua.hpp"
     #include "xref.hpp"
 
+
     generate!("qstring")
 
     // generate_pod!("cm_t")
@@ -58,6 +60,9 @@ include_cpp! {
     generate_pod!("filetype_t")
     generate_pod!("range_t")
     generate_pod!("uval_t")
+
+    // auto
+    generate!("auto_wait")
 
     // entry
     generate!("get_entry")
@@ -365,6 +370,7 @@ mod ffix {
         include!("comments_extras.h");
         include!("entry_extras.h");
         include!("func_extras.h");
+        include!("kernwin_extras.h");
         include!("inf_extras.h");
         include!("ph_extras.h");
         include!("segm_extras.h");
@@ -389,6 +395,8 @@ mod ffix {
         type segment_t = super::ffi::segment_t;
 
         unsafe fn init_library(argc: c_int, argv: *mut *mut c_char) -> c_int;
+
+        unsafe fn open_database_quiet(name: *const c_char, auto_analysis: bool) -> c_int;
 
         // NOTE: we can't use uval_t here due to it resolving to c_ulonglong,
         // which causes `verify_extern_type` to fail...
@@ -759,6 +767,8 @@ pub mod ida {
     use super::platform::is_main_thread;
     use super::{ea_t, ffi, ffix, IDAError};
 
+    pub use ffi::auto_wait;
+
     // NOTE: once; main thread
     pub fn init_library() -> Result<(), IDAError> {
         if !is_main_thread() {
@@ -816,6 +826,22 @@ pub mod ida {
         let path = CString::new(path.as_ref().to_string_lossy().as_ref()).map_err(IDAError::ffi)?;
 
         let res = unsafe { self::ffi::open_database(path.as_ptr(), auto_analysis) };
+
+        if res != c_int(0) {
+            Err(IDAError::OpenDb(res))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn open_database_quiet(path: impl AsRef<Path>, auto_analysis: bool) -> Result<(), IDAError> {
+        if !is_main_thread() {
+            panic!("IDA cannot function correctly when not running on the main thread");
+        }
+
+        let path = CString::new(path.as_ref().to_string_lossy().as_ref()).map_err(IDAError::ffi)?;
+
+        let res = unsafe { self::ffix::open_database_quiet(path.as_ptr(), auto_analysis) };
 
         if res != c_int(0) {
             Err(IDAError::OpenDb(res))

--- a/idalib/examples/bookmarks_ls.rs
+++ b/idalib/examples/bookmarks_ls.rs
@@ -4,7 +4,7 @@ fn main() -> anyhow::Result<()> {
     println!("Trying to open IDA database...");
 
     // Open IDA database
-    let idb = IDB::open_with("./tests/ls", true)?;
+    let idb = IDB::open_with("./tests/ls", true, true)?;
 
     println!("Testing erase(), get_description(), and len() (pass 1; clear old bookmarks)");
     for (_id, f) in idb.functions() {

--- a/idalib/examples/comments_ls.rs
+++ b/idalib/examples/comments_ls.rs
@@ -4,7 +4,7 @@ fn main() -> anyhow::Result<()> {
     println!("Trying to open IDA database... ");
 
     // Open IDA database
-    let idb = IDB::open_with("./tests/ls", true)?;
+    let idb = IDB::open_with("./tests/ls", true, true)?;
 
     println!("Testing remove_cmt() and get_cmt() (pass 1; clear old comments)");
     for (_id, f) in idb.functions() {

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_char;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 pub mod func;
@@ -16,10 +17,21 @@ pub type Address = u64;
 
 static INIT: OnceLock<Mutex<()>> = OnceLock::new();
 
+extern "C" {
+    static mut batch: c_char;
+}
+
 pub(crate) type IDARuntimeHandle = MutexGuard<'static, ()>;
 
-pub(crate) fn init_library() -> &'static Mutex<()> {
+pub fn force_batch_mode() {
+    unsafe {
+        batch = 1;
+    }
+}
+
+pub fn init_library() -> &'static Mutex<()> {
     INIT.get_or_init(|| {
+        force_batch_mode();
         ffi::ida::init_library().expect("IDA initialised successfully");
         Mutex::new(())
     })


### PR DESCRIPTION
This PR addresses two issues that cause idalib to emit undesired output to the console.

1. If we do not open any IDB or explicitly call `init_library`, since idalib registers `atexit` handlers (and `batch` is not set due to `init_library` not being called), "Thank you for using IDA. Have a nice day!" will be output.

To address this, we provide `force_batch_mode` which sets the `batch` global so that when the `atexit` handlers run they operate as if the library was initialised.

2. The implementation of idalib's `open_database` does not respect `enable_console_messages(false)`. Instead, it calls to `qvprintf` to log success and failure conditions...

To address this, we reimplement the core of `open_database` without compulsory status logging. Note that the logic to initialise debugger plugins present in the original version has not been included in the reimplementation; it will be added or exposed via the original function in a future PR (cc @yeggor).

The PR also:
- adds `IDB::auto_wait`.
- changes `IDB::open_with` API to allow waiting (or not) on `auto_wait` (second parameter).
- changes the visibility of `init_library` to public.