### PR TITLE
add the ability to find and run installed plugins

### DIFF
--- a/idalib-sys/build.rs
+++ b/idalib-sys/build.rs
@@ -33,20 +33,19 @@ fn main() {
 
     let ffi_path = PathBuf::from("src");
 
-    let mut builder =
-        autocxx_build::Builder::new(ffi_path.join("lib.rs"), &[&ffi_path, &ida])
-            .extra_clang_args(
-                #[cfg(target_os = "linux")]
-                &["-std=c++17", "-D__LINUX__=1", "-D__EA64__=1"],
-                #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-                &["-std=c++17", "-D__MACOS__=1", "-D__ARM__=1", "-D__EA64__=1"],
-                #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-                &["-std=c++17", "-D__MACOS__=1", "-D__EA64__=1"],
-                #[cfg(target_os = "windows")]
-                &["-std=c++17", "-D__NT__=1", "-D__EA64__=1"],
-            )
-            .build()
-            .expect("parsed correctly");
+    let mut builder = autocxx_build::Builder::new(ffi_path.join("lib.rs"), &[&ffi_path, &ida])
+        .extra_clang_args(
+            #[cfg(target_os = "linux")]
+            &["-std=c++17", "-D__LINUX__=1", "-D__EA64__=1"],
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            &["-std=c++17", "-D__MACOS__=1", "-D__ARM__=1", "-D__EA64__=1"],
+            #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+            &["-std=c++17", "-D__MACOS__=1", "-D__EA64__=1"],
+            #[cfg(target_os = "windows")]
+            &["-std=c++17", "-D__NT__=1", "-D__EA64__=1"],
+        )
+        .build()
+        .expect("parsed correctly");
 
     #[cfg(target_os = "linux")]
     {

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -382,6 +382,7 @@ mod ffix {
         include!("autocxxgen_ffi.h");
         include!("idalib.hpp");
 
+        include!("types.h");
         include!("bookmarks_extras.h");
         include!("bytes_extras.h");
         include!("comments_extras.h");
@@ -392,7 +393,6 @@ mod ffix {
         include!("kernwin_extras.h");
         include!("ph_extras.h");
         include!("segm_extras.h");
-        include!("types.h");
 
         type c_short = autocxx::c_short;
         type c_int = autocxx::c_int;

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -262,6 +262,17 @@ include_cpp! {
     generate!("plugin_t")
     generate!("find_plugin")
     generate!("run_plugin")
+
+    generate!("PLUGIN_MOD")
+    generate!("PLUGIN_DRAW")
+    generate!("PLUGIN_SEG")
+    generate!("PLUGIN_UNL")
+    generate!("PLUGIN_HIDE")
+    generate!("PLUGIN_DBG")
+    generate!("PLUGIN_PROC")
+    generate!("PLUGIN_FIX")
+    generate!("PLUGIN_MULTI")
+    generate!("PLUGIN_SCRIPTED")
 }
 
 pub mod idp {
@@ -376,6 +387,7 @@ mod ffix {
         include!("comments_extras.h");
         include!("entry_extras.h");
         include!("func_extras.h");
+        include!("loader_extras.h");
         include!("inf_extras.h");
         include!("kernwin_extras.h");
         include!("ph_extras.h");
@@ -400,6 +412,8 @@ mod ffix {
         type qflow_chart_t = super::ffi::qflow_chart_t;
         type qbasic_block_t = super::ffi::qbasic_block_t;
         type segment_t = super::ffi::segment_t;
+
+        type plugin_t = super::ffi::plugin_t;
 
         unsafe fn init_library(argc: c_int, argv: *mut *mut c_char) -> c_int;
 
@@ -625,6 +639,9 @@ mod ffix {
         unsafe fn idalib_get_dword(ea: c_ulonglong) -> u32;
         unsafe fn idalib_get_qword(ea: c_ulonglong) -> u64;
         unsafe fn idalib_get_bytes(ea: c_ulonglong, buf: &mut Vec<u8>) -> Result<usize>;
+
+        unsafe fn idalib_plugin_version(p: *const plugin_t) -> u64;
+        unsafe fn idalib_plugin_flags(p: *const plugin_t) -> u64;
     }
 }
 
@@ -782,6 +799,14 @@ pub mod bookmarks {
 
 pub mod loader {
     pub use super::ffi::{find_plugin, plugin_t, run_plugin};
+    pub use super::ffix::{idalib_plugin_flags, idalib_plugin_version};
+
+    pub mod flags {
+        pub use super::super::ffi::{
+            PLUGIN_DBG, PLUGIN_DRAW, PLUGIN_FIX, PLUGIN_HIDE, PLUGIN_MOD, PLUGIN_MULTI,
+            PLUGIN_PROC, PLUGIN_SCRIPTED, PLUGIN_SEG, PLUGIN_UNL,
+        };
+    }
 }
 
 pub mod ida {

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -45,6 +45,7 @@ include_cpp! {
     #include "ida.hpp"
     #include "idalib.hpp"
     #include "idp.hpp"
+    #include "loader.hpp"
     #include "moves.hpp"
     #include "pro.h"
     #include "segment.hpp"
@@ -256,6 +257,11 @@ include_cpp! {
     // comments
     generate!("set_cmt")
     generate!("append_cmt")
+
+    // loader
+    generate!("plugin_t")
+    generate!("find_plugin")
+    generate!("run_plugin")
 }
 
 pub mod idp {
@@ -365,16 +371,16 @@ mod ffix {
         include!("autocxxgen_ffi.h");
         include!("idalib.hpp");
 
-        include!("types.h");
         include!("bookmarks_extras.h");
         include!("bytes_extras.h");
         include!("comments_extras.h");
         include!("entry_extras.h");
         include!("func_extras.h");
-        include!("kernwin_extras.h");
         include!("inf_extras.h");
+        include!("kernwin_extras.h");
         include!("ph_extras.h");
         include!("segm_extras.h");
+        include!("types.h");
 
         type c_short = autocxx::c_short;
         type c_int = autocxx::c_int;
@@ -774,6 +780,10 @@ pub mod bookmarks {
     };
 }
 
+pub mod loader {
+    pub use super::ffi::{find_plugin, plugin_t, run_plugin};
+}
+
 pub mod ida {
     use std::env;
     use std::ffi::CString;
@@ -852,7 +862,10 @@ pub mod ida {
         }
     }
 
-    pub fn open_database_quiet(path: impl AsRef<Path>, auto_analysis: bool) -> Result<(), IDAError> {
+    pub fn open_database_quiet(
+        path: impl AsRef<Path>,
+        auto_analysis: bool,
+    ) -> Result<(), IDAError> {
         if !is_main_thread() {
             panic!("IDA cannot function correctly when not running on the main thread");
         }

--- a/idalib-sys/src/loader_extras.h
+++ b/idalib-sys/src/loader_extras.h
@@ -9,6 +9,7 @@
 uint64_t idalib_plugin_version(const plugin_t *p) {
   return p == nullptr ? 0 : p->version;
 }
+
 uint64_t idalib_plugin_flags(const plugin_t *p) {
   return p == nullptr ? 0 : p->flags;
 }

--- a/idalib-sys/src/loader_extras.h
+++ b/idalib-sys/src/loader_extras.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "loader.hpp"
+
+#include <cstdint>
+
+#include "cxx.h"
+
+uint64_t idalib_plugin_version(const plugin_t *p) {
+  return p == nullptr ? 0 : p->version;
+}
+uint64_t idalib_plugin_flags(const plugin_t *p) {
+  return p == nullptr ? 0 : p->flags;
+}

--- a/idalib/examples/patfind_ls.rs
+++ b/idalib/examples/patfind_ls.rs
@@ -7,6 +7,10 @@ fn main() -> anyhow::Result<()> {
     let idb = IDB::open("./tests/ls")?;
 
     let patfind = idb.find_plugin("patfind", true)?;
+
+    println!("patfind version: {}", patfind.version());
+    println!("patfind flags: {:#?}", patfind.flags());
+
     patfind.run(0);
 
     Ok(())

--- a/idalib/examples/patfind_ls.rs
+++ b/idalib/examples/patfind_ls.rs
@@ -1,0 +1,13 @@
+use idalib::enable_console_messages;
+use idalib::idb::*;
+
+fn main() -> anyhow::Result<()> {
+    enable_console_messages(true);
+
+    let idb = IDB::open("./tests/ls")?;
+
+    let patfind = idb.find_plugin("patfind", true)?;
+    patfind.run(0);
+
+    Ok(())
+}

--- a/idalib/examples/patfind_ls.rs
+++ b/idalib/examples/patfind_ls.rs
@@ -6,7 +6,7 @@ fn main() -> anyhow::Result<()> {
 
     let idb = IDB::open("./tests/ls")?;
 
-    let patfind = idb.find_plugin("patfind", true)?;
+    let patfind = idb.load_plugin("patfind")?;
 
     println!("patfind version: {}", patfind.version());
     println!("patfind flags: {:#?}", patfind.flags());

--- a/idalib/src/func.rs
+++ b/idalib/src/func.rs
@@ -8,9 +8,9 @@ use bitflags::bitflags;
 use cxx::UniquePtr;
 
 use crate::ffi::func::*;
+use crate::ffi::xref::has_external_refs;
 use crate::ffi::{range_t, IDAError, BADADDR};
 use crate::idb::IDB;
-use crate::ffi::xref::has_external_refs;
 use crate::Address;
 
 pub struct Function<'a> {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -339,10 +339,10 @@ impl IDB {
         let ptr = unsafe { find_plugin(plugin.as_ptr(), load_if_needed) };
 
         if ptr.is_null() {
-            return Err(IDAError::ffi_with(format!(
-                "failed load plugin {}",
+            Err(IDAError::ffi_with(format!(
+                "failed to load {} plugin",
                 name.as_ref()
-            )));
+            )))
         } else {
             Ok(Plugin::from_ptr(ptr))
         }

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -330,9 +330,13 @@ impl IDB {
         buf
     }
 
-    pub fn find_plugin(&self, name: impl AsRef<str>, load: bool) -> Result<Plugin, IDAError> {
+    pub fn find_plugin(
+        &self,
+        name: impl AsRef<str>,
+        load_if_needed: bool,
+    ) -> Result<Plugin, IDAError> {
         let plugin = CString::new(name.as_ref()).map_err(IDAError::ffi)?;
-        let ptr = unsafe { find_plugin(plugin.as_ptr(), load) };
+        let ptr = unsafe { find_plugin(plugin.as_ptr(), load_if_needed) };
 
         if ptr.is_null() {
             return Err(IDAError::ffi_with(format!(
@@ -342,6 +346,10 @@ impl IDB {
         } else {
             Ok(Plugin::from_ptr(ptr))
         }
+    }
+
+    pub fn load_plugin(&self, name: impl AsRef<str>) -> Result<Plugin, IDAError> {
+        self.find_plugin(name, true)
     }
 }
 

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -6,6 +6,7 @@ pub mod func;
 pub mod idb;
 pub mod insn;
 pub mod meta;
+pub mod plugin;
 pub mod processor;
 pub mod segment;
 pub mod xref;

--- a/idalib/src/plugin.rs
+++ b/idalib/src/plugin.rs
@@ -1,0 +1,24 @@
+use std::marker::PhantomData;
+
+use crate::ffi::loader::{plugin_t, run_plugin};
+use crate::idb::IDB;
+
+pub use crate::ffi::processor::ids as id;
+
+pub struct Plugin<'a> {
+    ptr: *const plugin_t,
+    _marker: PhantomData<&'a IDB>,
+}
+
+impl<'a> Plugin<'a> {
+    pub(crate) fn from_ptr(ptr: *const plugin_t) -> Self {
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn run(&self, arg: usize) -> bool {
+        unsafe { run_plugin(&*self.ptr, arg) }
+    }
+}

--- a/idalib/src/plugin.rs
+++ b/idalib/src/plugin.rs
@@ -1,9 +1,28 @@
 use std::marker::PhantomData;
+use std::mem;
 
-use crate::ffi::loader::{plugin_t, run_plugin};
+use bitflags::bitflags;
+
+use crate::ffi::loader::*;
 use crate::idb::IDB;
 
 pub use crate::ffi::processor::ids as id;
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct PluginFlags: u64 {
+        const MOD = flags::PLUGIN_MOD as u64;
+        const DRAW = flags::PLUGIN_DRAW as u64;
+        const SEG = flags::PLUGIN_SEG as u64;
+        const UNL = flags::PLUGIN_UNL as u64;
+        const HIDE = flags::PLUGIN_HIDE as u64;
+        const DBG = flags::PLUGIN_DBG as u64;
+        const PROC = flags::PLUGIN_PROC as u64;
+        const FIX = flags::PLUGIN_FIX as u64;
+        const MULTI = flags::PLUGIN_MULTI as u64;
+        const SCRIPTED = flags::PLUGIN_SCRIPTED as u64;
+    }
+}
 
 pub struct Plugin<'a> {
     ptr: *const plugin_t,
@@ -20,5 +39,14 @@ impl<'a> Plugin<'a> {
 
     pub fn run(&self, arg: usize) -> bool {
         unsafe { run_plugin(&*self.ptr, arg) }
+    }
+
+    pub fn version(&self) -> u64 {
+        unsafe { mem::transmute(idalib_plugin_version(self.ptr)) }
+    }
+
+    pub fn flags(&self) -> PluginFlags {
+        let bits = unsafe { mem::transmute(idalib_plugin_flags(self.ptr)) };
+        PluginFlags::from_bits_retain(bits)
     }
 }


### PR DESCRIPTION
`libida` is exporting only `make_signatures()` function which will find and run `makesig` plugin. I thought it would be nice to be able to run arbitrary plugins for different kinds of automation.

In this PR I'm adding a Plugin structure (wrapper around `plugin_t`) as well as an ability to find and run installed plugins. See `patfind_ls.rs` for usage:

```
patfind version: 900
patfind flags: PluginFlags(
    PROC | MULTI,
)
Patfind: Attempting to load pattern file: ~/ida-pro-9.0/cfg/ghidra_patterns/x86/data/patterns/x86-64gcc_patterns.xml
Patfind: Found 0 functions, in 0.001070 seconds
```