### PR TITLE
Expose "set show" family of functions

### DIFF
--- a/idalib-sys/src/inf_extras.h
+++ b/idalib-sys/src/inf_extras.h
@@ -270,7 +270,7 @@ bool idalib_inf_show_hidden_insns() { return inf_show_hidden_insns(); }
 bool idalib_inf_set_show_hidden_insns() { return inf_set_show_hidden_insns(); }
 
 bool idalib_inf_show_hidden_funcs() { return inf_show_hidden_funcs(); }
-bool idalib_inf_set_show_hidden_funcs() { return inf_set_show_hidden_insns(); }
+bool idalib_inf_set_show_hidden_funcs() { return inf_set_show_hidden_funcs(); }
 
 bool idalib_inf_show_hidden_segms() { return inf_show_hidden_segms(); }
 bool idalib_inf_set_show_hidden_segms() { return inf_set_show_hidden_segms(); }

--- a/idalib-sys/src/inf_extras.h
+++ b/idalib-sys/src/inf_extras.h
@@ -259,6 +259,7 @@ std::uint8_t idalib_inf_get_cmtflg()  { return inf_get_cmtflg(); }
 bool idalib_inf_show_repeatables() { return inf_show_repeatables(); }
 
 bool idalib_inf_show_all_comments() { return inf_show_all_comments(); }
+bool idalib_inf_set_show_all_comments() { return inf_set_show_all_comments(); }
 
 bool idalib_inf_hide_comments() { return inf_hide_comments(); }
 
@@ -266,10 +267,13 @@ bool idalib_inf_show_src_linnum() { return inf_show_src_linnum(); }
 
 bool idalib_inf_test_mode() { return inf_test_mode(); }
 bool idalib_inf_show_hidden_insns() { return inf_show_hidden_insns(); }
+bool idalib_inf_set_show_hidden_insns() { return inf_set_show_hidden_insns(); }
 
 bool idalib_inf_show_hidden_funcs() { return inf_show_hidden_funcs(); }
+bool idalib_inf_set_show_hidden_funcs() { return inf_set_show_hidden_insns(); }
 
 bool idalib_inf_show_hidden_segms() { return inf_show_hidden_segms(); }
+bool idalib_inf_set_show_hidden_segms() { return inf_set_show_hidden_segms(); }
 
 
 std::uint8_t idalib_inf_get_limiter()  { return inf_get_limiter(); }

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -450,7 +450,9 @@ pub mod inf {
         idalib_inf_pack_stkargs, idalib_inf_prefix_show_funcoff, idalib_inf_prefix_show_segaddr,
         idalib_inf_prefix_show_stack, idalib_inf_prefix_truncate_opcode_bytes,
         idalib_inf_propagate_regargs, idalib_inf_propagate_stkargs, idalib_inf_readonly_idb,
-        idalib_inf_rename_jumpfunc, idalib_inf_rename_nullsub, idalib_inf_should_create_stkvars,
+        idalib_inf_rename_jumpfunc, idalib_inf_rename_nullsub, idalib_inf_set_show_all_comments,
+        idalib_inf_set_show_hidden_funcs, idalib_inf_set_show_hidden_insns,
+        idalib_inf_set_show_hidden_segms, idalib_inf_should_create_stkvars,
         idalib_inf_should_trace_sp, idalib_inf_show_all_comments, idalib_inf_show_auto,
         idalib_inf_show_hidden_funcs, idalib_inf_show_hidden_insns, idalib_inf_show_hidden_segms,
         idalib_inf_show_line_pref, idalib_inf_show_repeatables, idalib_inf_show_src_linnum,
@@ -672,12 +674,16 @@ mod ffix {
         unsafe fn idalib_inf_get_cmtflg() -> u8;
         unsafe fn idalib_inf_show_repeatables() -> bool;
         unsafe fn idalib_inf_show_all_comments() -> bool;
+        unsafe fn idalib_inf_set_show_all_comments() -> bool;
         unsafe fn idalib_inf_hide_comments() -> bool;
         unsafe fn idalib_inf_show_src_linnum() -> bool;
         unsafe fn idalib_inf_test_mode() -> bool;
         unsafe fn idalib_inf_show_hidden_insns() -> bool;
+        unsafe fn idalib_inf_set_show_hidden_insns() -> bool;
         unsafe fn idalib_inf_show_hidden_funcs() -> bool;
+        unsafe fn idalib_inf_set_show_hidden_funcs() -> bool;
         unsafe fn idalib_inf_show_hidden_segms() -> bool;
+        unsafe fn idalib_inf_set_show_hidden_segms() -> bool;
         unsafe fn idalib_inf_get_limiter() -> u8;
         unsafe fn idalib_inf_is_limiter_thin() -> bool;
         unsafe fn idalib_inf_is_limiter_thick() -> bool;

--- a/idalib/examples/comments_ls.rs
+++ b/idalib/examples/comments_ls.rs
@@ -44,7 +44,6 @@ fn main() -> anyhow::Result<()> {
     println!("Testing find_text_iter()");
     let results: Vec<_> = idb.find_text_iter("added by idalib").collect();
     assert!(!results.is_empty());
-    // FIXME: text search doesn't display results located in collapsed functions
     assert_eq!(results.len(), idb.functions().count());
 
     println!("Testing append_cmt() and get_cmt()");

--- a/idalib/examples/comments_ls.rs
+++ b/idalib/examples/comments_ls.rs
@@ -4,7 +4,10 @@ fn main() -> anyhow::Result<()> {
     println!("Trying to open IDA database...");
 
     // Open IDA database
-    let idb = IDB::open_with("./tests/ls", true, true)?;
+    let mut idb = IDB::open_with("./tests/ls", true, true)?;
+
+    // Show all functions
+    idb.meta_mut().set_show_hidden_funcs();
 
     println!("Testing remove_cmt() and get_cmt() (pass 1; clear old comments)");
     for (_id, f) in idb.functions() {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -23,7 +23,7 @@ use crate::bookmarks::Bookmarks;
 use crate::decompiler::CFunction;
 use crate::func::{Function, FunctionId};
 use crate::insn::{Insn, Register};
-use crate::meta::Metadata;
+use crate::meta::{Metadata, MetadataMut};
 use crate::plugin::Plugin;
 use crate::processor::Processor;
 use crate::segment::{Segment, SegmentId};
@@ -90,6 +90,10 @@ impl IDB {
 
     pub fn meta<'a>(&'a self) -> Metadata<'a> {
         Metadata::new()
+    }
+
+    pub fn meta_mut<'a>(&'a mut self) -> MetadataMut<'a> {
+        MetadataMut::new()
     }
 
     pub fn processor<'a>(&'a self) -> Processor<'a> {

--- a/idalib/src/meta.rs
+++ b/idalib/src/meta.rs
@@ -805,3 +805,31 @@ impl<'a> Metadata<'a> {
         unsafe { idalib_inf_get_strlit_pref() }
     }
 }
+
+pub struct MetadataMut<'a> {
+    _marker: PhantomData<&'a mut IDB>,
+}
+
+impl<'a> MetadataMut<'a> {
+    pub(crate) fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn set_show_all_comments(&mut self) -> bool {
+        unsafe { idalib_inf_set_show_all_comments() }
+    }
+
+    pub fn set_show_hidden_insns(&mut self) -> bool {
+        unsafe { idalib_inf_set_show_hidden_insns() }
+    }
+
+    pub fn set_show_hidden_funcs(&mut self) -> bool {
+        unsafe { idalib_inf_set_show_hidden_funcs() }
+    }
+
+    pub fn set_show_hidden_segms(&mut self) -> bool {
+        unsafe { idalib_inf_set_show_hidden_segms() }
+    }
+}


### PR DESCRIPTION
This PR adds `IDB::meta_mut` and `MetadataMut`, which provide the following API:

- `set_show_all_comments`
- `set_show_hidden_funcs`
- `set_show_hidden_insns`
- `set_show_hidden_segm`