### PR TITLE
Feature/bookmarks get address

### DIFF
--- a/idalib-sys/src/bookmarks_extras.h
+++ b/idalib-sys/src/bookmarks_extras.h
@@ -33,6 +33,26 @@ rust::String idalib_bookmarks_t_get_desc(uint32 index) {
   }
 }
 
+ea_t idalib_bookmarks_t_get(uint32 index) {
+  auto desc = qstring();
+  ea_t ea = 0;
+
+  idaplace_t ipl(ea, 0);
+  renderer_info_t rinfo;
+  rinfo.rtype = TCCRT_FLAT;
+  rinfo.pos.cx = 0;
+  rinfo.pos.cy = 5;
+  lochist_entry_t e(&ipl, rinfo);
+
+  lochist_entry_t loc(e);
+
+  if (bookmarks_t_get(&loc, &desc, &index, nullptr) != 0) {
+    return loc.place()->toea();
+  } else {
+    return BADADDR;
+  }
+}
+
 bool idalib_bookmarks_t_erase(uint32 index) {
   ea_t ea = 0;
 

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -757,6 +757,7 @@ mod ffix {
             desc: *const c_char,
         ) -> u32;
         unsafe fn idalib_bookmarks_t_get_desc(index: c_uint) -> String;
+        unsafe fn idalib_bookmarks_t_get(index: c_uint) -> c_ulonglong;
         unsafe fn idalib_bookmarks_t_erase(index: c_uint) -> bool;
         unsafe fn idalib_bookmarks_t_size() -> u32;
         unsafe fn idalib_bookmarks_t_find_index(ea: c_ulonglong) -> u32;
@@ -923,8 +924,8 @@ pub mod comments {
 
 pub mod bookmarks {
     pub use super::ffix::{
-        idalib_bookmarks_t_erase, idalib_bookmarks_t_find_index, idalib_bookmarks_t_get_desc,
-        idalib_bookmarks_t_mark, idalib_bookmarks_t_size,
+        idalib_bookmarks_t_erase, idalib_bookmarks_t_find_index, idalib_bookmarks_t_get,
+        idalib_bookmarks_t_get_desc, idalib_bookmarks_t_mark, idalib_bookmarks_t_size,
     };
 }
 

--- a/idalib/examples/bookmarks_ls.rs
+++ b/idalib/examples/bookmarks_ls.rs
@@ -38,6 +38,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     println!("Testing len(), get_address(), and get_description()");
+    // len()
     for i in 0..idb.bookmarks().len() {
         // get_address()
         let read_addr = idb.bookmarks().get_address(i).unwrap();

--- a/idalib/examples/bookmarks_ls.rs
+++ b/idalib/examples/bookmarks_ls.rs
@@ -25,9 +25,8 @@ fn main() -> anyhow::Result<()> {
     for (id, f) in idb.functions() {
         let addr = f.start_address();
         let desc = format!(
-            "Bookmark added by idalib: {id} {} {:#x}",
+            "Bookmark added by idalib: {id} {} {addr:#x}",
             f.name().unwrap(),
-            addr
         );
 
         // mark()
@@ -36,6 +35,18 @@ fn main() -> anyhow::Result<()> {
         // get_description()
         let read_desc = idb.bookmarks().get_description(addr);
         assert_eq!(read_desc.unwrap(), desc);
+    }
+
+    println!("Testing len(), get_address(), and get_description()");
+    for i in 0..idb.bookmarks().len() {
+        // get_address()
+        let read_addr = idb.bookmarks().get_address(i).unwrap();
+        let addr_str = format!("{read_addr:#x}");
+
+        // get_description()
+        let read_desc = idb.bookmarks().get_description(read_addr).unwrap();
+
+        assert!(read_desc.ends_with(addr_str.as_str()));
     }
 
     println!("Testing erase(), get_description(), and len() (pass 2)");

--- a/idalib/examples/comments_ls.rs
+++ b/idalib/examples/comments_ls.rs
@@ -22,9 +22,8 @@ fn main() -> anyhow::Result<()> {
     for (id, f) in idb.functions() {
         let addr = f.start_address();
         let comment = format!(
-            "Comment added by idalib: {id} {} {:#x}",
-            f.name().unwrap(),
-            addr
+            "Comment added by idalib: {id} {} {addr:#x}",
+            f.name().unwrap()
         );
 
         // set_cmt()

--- a/idalib/src/bookmarks.rs
+++ b/idalib/src/bookmarks.rs
@@ -2,9 +2,10 @@ use std::ffi::CString;
 use std::marker::PhantomData;
 
 use crate::ffi::bookmarks::{
-    idalib_bookmarks_t_erase, idalib_bookmarks_t_find_index, idalib_bookmarks_t_get_desc,
-    idalib_bookmarks_t_mark, idalib_bookmarks_t_size,
+    idalib_bookmarks_t_erase, idalib_bookmarks_t_find_index, idalib_bookmarks_t_get,
+    idalib_bookmarks_t_get_desc, idalib_bookmarks_t_mark, idalib_bookmarks_t_size,
 };
+use crate::ffi::BADADDR;
 
 use crate::idb::IDB;
 use crate::{Address, IDAError};
@@ -55,6 +56,17 @@ impl<'a> Bookmarks<'a> {
 
     pub fn get_description(&self, ea: Address) -> Option<String> {
         self.get_description_by_index(self.find_index(ea)?)
+    }
+
+    // Note: The `bookmarks_t::get` function is used here only to get the address
+    pub fn get_address(&self, idx: BookmarkIndex) -> Option<Address> {
+        let addr = unsafe { idalib_bookmarks_t_get(idx.into()) };
+
+        if addr == BADADDR {
+            None
+        } else {
+            Some(addr.into())
+        }
     }
 
     // Note: The address parameter has been removed because it is unused by IDA's API


### PR DESCRIPTION
Hi! I've added a `get_address()` function to the bookmarks API, because I needed it for my integration tests. I've used `bookmarks_t::get` to implement it, keeping only the address that I was interested in and discarding the rest of the output.