### PR TITLE
Add support for decompiler error reporting

### DIFF
--- a/idalib-sys/src/hexrays_extras.h
+++ b/idalib-sys/src/hexrays_extras.h
@@ -10,6 +10,17 @@
 
 #include "cxx.h"
 
+#ifndef CXXBRIDGE1_STRUCT_hexrays_error_t
+#define CXXBRIDGE1_STRUCT_hexrays_error_t
+struct hexrays_error_t final {
+  ::std::int32_t code;
+  ::std::uint64_t addr;
+  ::rust::String desc;
+
+  using IsRelocatable = ::std::true_type;
+};
+#endif // CXXBRIDGE1_STRUCT_hexrays_error_t
+
 struct cblock_iter {
   qlist<cinsn_t>::iterator start;
   qlist<cinsn_t>::iterator end;
@@ -18,6 +29,22 @@ struct cblock_iter {
 };
 
 cfunc_t *idalib_hexrays_cfuncptr_inner(const cfuncptr_t *f) { return *f; }
+
+std::unique_ptr<cfuncptr_t>
+idalib_hexrays_decompile_func(func_t *f, hexrays_error_t *err, int flags) {
+  hexrays_failure_t failure;
+  cfuncptr_t cf = decompile_func(f, &failure, flags);
+
+  if (failure.code >= 0 && cf != nullptr) {
+    return std::unique_ptr<cfuncptr_t>(new cfuncptr_t(cf));
+  }
+
+  err->code = failure.code;
+  err->desc = rust::String(failure.desc().c_str());
+  err->addr = failure.errea;
+
+  return nullptr;
+}
 
 rust::String idalib_hexrays_cfunc_pseudocode(cfunc_t *f) {
   auto sv = f->get_pseudocode();
@@ -44,6 +71,4 @@ cinsn_t *idalib_hexrays_cblock_iter_next(cblock_iter &it) {
   return nullptr;
 }
 
-std::size_t idalib_hexrays_cblock_len(cblock_t *b) {
-  return b->size();
-}
+std::size_t idalib_hexrays_cblock_len(cblock_t *b) { return b->size(); }

--- a/idalib/src/decompiler.rs
+++ b/idalib/src/decompiler.rs
@@ -7,6 +7,8 @@ use crate::ffi::hexrays::{
 };
 use crate::idb::IDB;
 
+pub use crate::ffi::hexrays::{HexRaysError, HexRaysErrorCode};
+
 pub struct CFunction<'a> {
     ptr: *mut cfunc_t,
     _obj: cxx::UniquePtr<cfuncptr_t>,


### PR DESCRIPTION
This PR allows us to check why a function failed to decompile; it adds `HexRaysError` and `HexRaysErrorCode` types that allow us to get the reason, address, and "error code" associated with a decompilation failure. It changes `IDB::decompile` and `IDB::decompile_with` to return a `Result`; the decompiler error can be accessed via `IDAError::HexRays`.

Fixes #21.

Example via `dump_ls` (incompatible license):

```
function 632 @ 444a24: Some("__cxa_atexit") (blocks: 1) (decompiled: false)
decompilation failed: License / license not available (HEXMIPS)
--- blk 0 @ 444a24-444a28 ---
- insn: (ea: 444a24, size: 4, operands: 0)
- ret: false
- noret: false
- enoret: false
- cndret: false
- indjump: false
- extern: false
```

Example via `dump_ls` (extern):

```
function 175 @ c390: Some("__gmon_start__") (blocks: 1) (decompiled: false)
decompilation failed: Extern / special segments cannot be decompiled
--- blk 0 @ c390-c398 ---
- insn: (ea: c390, size: 8, operands: 0)
- ret: true
- noret: false
- enoret: false
- cndret: false
- indjump: false
- extern: false
```