### PR TITLE
update license_location_t and config_t structures

### DIFF
--- a/idalib-sys/src/kernwin_extras.h
+++ b/idalib-sys/src/kernwin_extras.h
@@ -52,7 +52,11 @@ struct license_addon_info_t {
 };
 
 struct license_manager_t_vtbl {
+#if defined(__NT__)
+  void *_skip_a[3];
+#else
   void *_skip_a[4];
+#endif
   int (*get_or_borrow_license)(license_manager_t *, void *, license_info_t *,
                                uint64_t, qstring *);
   void *(*get_license_location)(license_manager_t *);

--- a/idalib-sys/src/kernwin_extras.h
+++ b/idalib-sys/src/kernwin_extras.h
@@ -26,6 +26,9 @@ struct license_location_t {
   uint8_t _skip_b;
   uint32_t _skip_c;
   uint64_t remote;
+#if defined(__NT__)
+  uint64_t _skip_d;
+#endif
   qstring license_path;
   qstring license_path_pattern;
 };
@@ -81,7 +84,13 @@ struct license_manager_t {
 };
 
 struct config_t {
+#if defined(__MACOS__)
   char _skip_a[0x530];
+#elif defined(__LINUX__)
+  char _skip_a[0x578];
+#elif defined(__NT__)
+  char _skip_a[0x528];
+#endif
   license_location_t license_location;
   license_info_t license_info;
 };


### PR DESCRIPTION
Make `license_location_t` and `config_t` structures compatible with linux and windows.