### PR TITLE
Make force_batch_mode a no-op on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1 (2025-02-28)
+
+Bugfix:
+- Make `idalib::force_batch_mode` a no-op on Windows.
+
 ## 0.5.0 (2025-02-28)
 
 Compatibility release for IDA 9.1.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # idalib
 
 [![crates.io](https://img.shields.io/crates/v/idalib)](https://crates.io/crates/idalib)
-[![documentation](https://img.shields.io/badge/documentation-0.5.0%2B9.1.250226-blue?link=https%3A%2F%2Fbinarly-io.github.io%2Fidalib%2Fidalib)](https://binarly-io.github.io/idalib/idalib/)
+[![documentation](https://img.shields.io/badge/documentation-0.5.1%2B9.1.250226-blue?link=https%3A%2F%2Fbinarly-io.github.io%2Fidalib%2Fidalib)](https://binarly-io.github.io/idalib/idalib/)
 [![license](https://img.shields.io/crates/l/idalib)](https://github.com/binarly-io/idalib)
 [![crates.io downloads](https://img.shields.io/crates/d/idalib)](https://crates.io/crates/idalib)
 
@@ -17,7 +17,7 @@ release. See the table below for compatibility:
 
 | IDA Pro version | Latest compatible idalib |
 | --------------- | ------------------------ |
-| v9.1            | 0.5.0                    |
+| v9.1            | 0.5.1                    |
 | v9.0sp1         | 0.4.1                    |
 | v9.0            | 0.3.0                    |
 

--- a/idalib-build/Cargo.toml
+++ b/idalib-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idalib-build"
 authors = ["Sam L. Thomas <sam@binarly.io>", "Yegor Vasilenko <yegor@binarly.io>"]
-version = "0.5.0+9.1.250226"
+version = "0.5.1+9.1.250226"
 description = "Idiomatic bindings to IDA SDK"
 repository = "https://github.com/binarly-io/idalib"
 documentation = "https://binarly-io.github.io/idalib/idalib_build"

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idalib-sys"
 authors = ["Sam L. Thomas <sam@binarly.io>", "Yegor Vasilenko <yegor@binarly.io>"]
-version = "0.5.0+9.1.250226"
+version = "0.5.1+9.1.250226"
 description = "Idiomatic bindings to IDA SDK"
 repository = "https://github.com/binarly-io/idalib"
 documentation = "https://binarly-io.github.io/idalib/idalib_sys"

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idalib"
 authors = ["Sam L. Thomas <sam@binarly.io>", "Yegor Vasilenko <yegor@binarly.io>"]
-version = "0.5.0+9.1.250226"
+version = "0.5.1+9.1.250226"
 description = "Idiomatic bindings to IDA SDK"
 repository = "https://github.com/binarly-io/idalib"
 documentation = "https://binarly-io.github.io/idalib/idalib"

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -101,6 +101,7 @@ pub type Address = u64;
 
 static INIT: OnceLock<Mutex<()>> = OnceLock::new();
 
+#[cfg(not(target_os = "windows"))]
 extern "C" {
     static mut batch: c_char;
 }
@@ -108,6 +109,7 @@ extern "C" {
 pub(crate) type IDARuntimeHandle = MutexGuard<'static, ()>;
 
 pub fn force_batch_mode() {
+    #[cfg(not(target_os = "windows"))]
     unsafe {
         batch = 1;
     }


### PR DESCRIPTION
Setting the `batch` global causes crashes on Windows.