### PR TITLE
fix: update llvm version in windows build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: install clang/llvm
-        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
+        uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "18.1.8"
-          directory: "${{ runner.temp }}/llvm-18"
+          version: "20"
+          directory: "${{ runner.temp }}/llvm-20"
       - name: configure clang/llvm environment
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: install clang/llvm
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@a7a1a882e2d06ebe05d5bb97c3e1f8c984ae96fc
         with:
           version: "20"
           directory: "${{ runner.temp }}/llvm-20"

--- a/GITHUB-ACTIONS.md
+++ b/GITHUB-ACTIONS.md
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: install clang/llvm
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@a7a1a882e2d06ebe05d5bb97c3e1f8c984ae96fc
         with:
           version: "20"
           directory: "${{ runner.temp }}/llvm-20"

--- a/GITHUB-ACTIONS.md
+++ b/GITHUB-ACTIONS.md
@@ -100,10 +100,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: install clang/llvm
-        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
+        uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "18.1.8"
-          directory: "${{ runner.temp }}/llvm-18"
+          version: "20"
+          directory: "${{ runner.temp }}/llvm-20"
       - name: configure clang/llvm environment
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
       - name: checkout


### PR DESCRIPTION
I've updated the Clang/LLVM version in the `build-windows` GitHub action to fix the following error that manifested with the current `windows-latest` actions runner image:

```
ParseError(AutocxxCodegenError(Bindgen(ClangDiagnostic("C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.44.35207\\include\\yvals_core.h:908:1: error: static assertion failed: error STL1000: Unexpected compiler version, expected Clang 19.0.0 or newer.\n"))))
```

I've also updated the GitHub Actions documentation accordingly.

Cheers!