### PR TITLE
Enable -T support (added in IDA 9.2)

### DIFF
--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -45,7 +45,8 @@ pub struct IDB {
 #[derive(Debug, Clone)]
 pub struct IDBOpenOptions {
     idb: Option<PathBuf>,
-    // ftype: Option<String>,
+    ftype: Option<String>,
+
     save: bool,
     auto_analyse: bool,
 }
@@ -54,7 +55,7 @@ impl Default for IDBOpenOptions {
     fn default() -> Self {
         Self {
             idb: None,
-            // ftype: None,
+            ftype: None,
             save: false,
             auto_analyse: true,
         }
@@ -76,17 +77,10 @@ impl IDBOpenOptions {
         self
     }
 
-    // NOTE: as of IDA 9.1, the file type switch does not work as documented;
-    // we get the following log output:
-    //
-    // ```
-    // Unknown switch '-T' -> OK
-    // ```
-    //
-    // pub fn file_type(&mut self, ftype: impl AsRef<str>) -> &mut Self {
-    //   self.ftype = Some(ftype.as_ref().to_owned());
-    //   self
-    // }
+    pub fn file_type(&mut self, ftype: impl AsRef<str>) -> &mut Self {
+        self.ftype = Some(ftype.as_ref().to_owned());
+        self
+    }
 
     pub fn auto_analyse(&mut self, auto_analyse: bool) -> &mut Self {
         self.auto_analyse = auto_analyse;
@@ -96,11 +90,9 @@ impl IDBOpenOptions {
     pub fn open(&self, path: impl AsRef<Path>) -> Result<IDB, IDAError> {
         let mut args = Vec::new();
 
-        // NOTE: for now, we will disable this functionality (see comment on file_type above).
-        //
-        // if let Some(ftype) = self.ftype.as_ref() {
-        //    args.push(format!("-T{}", ftype));
-        // }
+        if let Some(ftype) = self.ftype.as_ref() {
+            args.push(format!("-T{}", ftype));
+        }
 
         if let Some(idb_path) = self.idb.as_ref() {
             args.push("-c".to_owned());


### PR DESCRIPTION
It also wraps ida92 support in a new feature flag, so we can have ida91 and ida92 side-by-side until 92 support is more widespread.