### PR TITLE
Change URL of the SDK submodule from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "idalib-sys/sdk"]
 	path = idalib-sys/sdk
-	url = git@github.com:HexRaysSA/ida-sdk.git
+	url = https://github.com/HexRaysSA/ida-sdk.git


### PR DESCRIPTION
Hi Sam,

Great job as usual with the timely release of a new idalib! I'm in the process of porting my tools as well.

I'm proposing just a minor change, to prevent submodule update errors in case the developer doesn't have an SSH key configured on GitHub, i.e.:
```
raptor@fnord RustroverProjects % git clone https://github.com/0xdea/idalib
Cloning into 'idalib'...
remote: Enumerating objects: 979, done.
remote: Counting objects: 100% (333/333), done.
remote: Compressing objects: 100% (137/137), done.
remote: Total 979 (delta 261), reused 203 (delta 194), pack-reused 646 (from 3)
Receiving objects: 100% (979/979), 595.06 KiB | 7.26 MiB/s, done.
Resolving deltas: 100% (623/623), done.
raptor@fnord RustroverProjects % cd idalib
raptor@fnord idalib % git submodule update --init --recursive
Submodule 'idalib-sys/sdk' (git@github.com:HexRaysSA/ida-sdk.git) registered for path 'idalib-sys/sdk'
Cloning into '/Users/raptor/RustroverProjects/idalib/idalib-sys/sdk'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:HexRaysSA/ida-sdk.git' into submodule path '/Users/raptor/RustroverProjects/idalib/idalib-sys/sdk' failed
Failed to clone 'idalib-sys/sdk'. Retry scheduled
Cloning into '/Users/raptor/RustroverProjects/idalib/idalib-sys/sdk'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:HexRaysSA/ida-sdk.git' into submodule path '/Users/raptor/RustroverProjects/idalib/idalib-sys/sdk' failed
Failed to clone 'idalib-sys/sdk' a second time, aborting
```

After applying the proposed change to `.gitmodules`, it works as expected:
```
raptor@fnord idalib % git submodule sync

Synchronizing submodule url for 'idalib-sys/sdk'
raptor@fnord idalib % git submodule update --init --recursive

Cloning into '/Users/raptor/RustroverProjects/idalib/idalib-sys/sdk'...
Submodule path 'idalib-sys/sdk': checked out '7acfc0f417a116775012f0f154deb43b62d5a43d'
```

If you don't have a particular reason for using SSH, you might want to switch to this more permissive configuration.

Cheers!