### PR TITLE
Fix some clippy lints and other minor adjustments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "idalib-sys/sdk"]
 	path = idalib-sys/sdk
-	url = git@github.com:HexRaysSA/ida-sdk.git
+	url = https://github.com/HexRaysSA/ida-sdk.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.1 (2025-09-13)
 
 Bugfix:
+
 - Fix idalib-build so it correctly references the SDK.
 
 ## 0.7.0 (2025-09-12)
@@ -10,12 +11,14 @@ Bugfix:
 Compatibility release for IDA 9.2.
 
 Features:
+
 - Additional comment APIs (contributor:
   [@Irate-Walrus](https://github.com/Irate-Walrus)).
 - File type selection via `IDBOpenOptions` (contributor:
   [@withzombies](https://github.com/withzombies)).
 
 Miscellaneous:
+
 - Use open-source IDA SDK as a submodule.
 - Downgrade to autocxx 0.27.x due to build issues reported by
   [@coleleavitt](https://github.com/coleleavitt).
@@ -25,8 +28,9 @@ Miscellaneous:
 ## 0.6.1 (2025-07-15)
 
 Features:
+
 - Add string list iterator (contributor:
-  [@williballenthin](https://github.com/williballenthin)]).
+  [@williballenthin](https://github.com/williballenthin)).
 - Add `input_file_path`, `input_file_size`, `input_file_sha256`,
   `input_file_md5` to `Metadata`.
 - Add `NameList`, `NameListIterator`, and `Name` to access/iterate over names
@@ -36,12 +40,14 @@ Features:
 - Add `idalib::version` to get the IDA version information.
 
 Miscellaneous:
+
 - Update GitHub workflows to fix Windows build issues. (contributor:
   [@0xdea](https://github.com/0xdea)).
 
 ## 0.6.0 (2025-05-21)
 
 Features:
+
 - Add `IDBOpenOptions` to supply additional "command line" arguments during
   database open, e.g., to set database location.
 - Add `IDB::segment_by_name`.
@@ -52,12 +58,14 @@ Features:
   `SegmentPermissions`, and `SegmentType`.
 
 Miscellaneous:
+
 - Support for Rust 2024 edition.
 - Switch to https://idalib.rs/ domain for documentation.
 
 ## 0.5.1 (2025-02-28)
 
 Bugfix:
+
 - Make `idalib::force_batch_mode` a no-op on Windows.
 
 ## 0.5.0 (2025-02-28)
@@ -67,6 +75,7 @@ Compatibility release for IDA 9.1.
 ## 0.4.1 (2025-02-24)
 
 Features:
+
 - Add additional sanity checks when creating/opening an IDB to prevent IDA
   causing the consumer to exit.
 - Bump autocxx dependency.
@@ -78,17 +87,20 @@ Compatibility release for IDA 9.0sp1.
 ## 0.3.0 (2024-12-04)
 
 Features:
+
 - Improved error reporting for decompiler.
 - Add string list API (contributor: [@0xdea](https://github.com/0xdea)).
 
 ## 0.2.2 (2024-11-16)
 
 Fix:
+
 - Documentation generation and workflow.
 
 ## 0.2.1 (2024-11-16)
 
 Features:
+
 - Add `Bookmarks::get_address` (contributor: [@0xdea](https://github.com/0xdea)).
 - Add search API (contributor: [@0xdea](https://github.com/0xdea)).
 - Add "set show" family of functions.
@@ -96,6 +108,7 @@ Features:
 ## 0.2.0 (2024-11-13)
 
 Features:
+
 - Bookmarks API (contributor: [@0xdea](https://github.com/0xdea)).
 - Build system improvements to avoid idalib-sys rebuilds (contributor:
   [@Bobo1239](https://github.com/Bobo1239)).
@@ -109,6 +122,7 @@ Features:
 ## 0.1.1 (2024-10-27)
 
 Features:
+
 - Comments API (contributor: [@0xdea](https://github.com/0xdea)).
 
 ## 0.1.0 (2024-09-30)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bindings are only guaranteed compatible with the latest official IDA Pro/SDK
 release. See the table below for compatibility:
 
 | IDA Pro version | Latest compatible idalib |
-| --------------- | ------------------------ |
+|-----------------|--------------------------|
 | v9.2            | 0.7.1                    |
 | v9.1            | 0.6.1                    |
 | v9.0sp1         | 0.4.1                    |

--- a/idalib-build/Cargo.toml
+++ b/idalib-build/Cargo.toml
@@ -16,3 +16,17 @@ build = "build.rs"
 [dependencies]
 anyhow = "1"
 idalib-sys = { version = "0.7", path = "../idalib-sys" }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+wildcard_imports = "allow"
+enum_glob_use = "allow"
+unreadable_literal = "allow"
+multiple_crate_versions = "allow"
+significant_drop_tightening = "allow"
+must_use_candidate = "allow"

--- a/idalib-build/Cargo.toml
+++ b/idalib-build/Cargo.toml
@@ -16,17 +16,3 @@ build = "build.rs"
 [dependencies]
 anyhow = "1"
 idalib-sys = { version = "0.7", path = "../idalib-sys" }
-
-[lints.clippy]
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-wildcard_imports = "allow"
-enum_glob_use = "allow"
-unreadable_literal = "allow"
-multiple_crate_versions = "allow"
-significant_drop_tightening = "allow"
-must_use_candidate = "allow"

--- a/idalib-build/src/lib.rs
+++ b/idalib-build/src/lib.rs
@@ -20,9 +20,11 @@ pub fn idalib_sdk_paths_with(check: bool) -> (PathBuf, PathBuf, PathBuf, PathBuf
     let sdk_path = PathBuf::from(env!("IDALIB_SDK"));
     let pro_h = sdk_path.join("include").join("pro.h");
 
-    if check && !pro_h.exists() {
-        panic!("`{}` does not exist; SDK is not usable", pro_h.display());
-    }
+    assert!(
+        !check || pro_h.exists(),
+        "`{}` does not exist; SDK is not usable",
+        pro_h.display()
+    );
 
     let (stubs_path, idalib, ida) = if cfg!(target_os = "linux") {
         let path = sdk_path.join("lib/x64_linux_gcc_64");
@@ -67,12 +69,11 @@ pub fn idalib_install_paths_with(check: bool) -> (PathBuf, PathBuf, PathBuf) {
         panic!("unsupported platform")
     };
 
-    if check && !idalib.exists() {
-        panic!(
-            "`{}` does not exist; cannot find a compatible IDA Pro installation",
-            idalib.display()
-        );
-    }
+    assert!(
+        !check || idalib.exists(),
+        "`{}` does not exist; cannot find a compatible IDA Pro installation",
+        idalib.display()
+    );
 
     (path, idalib, ida)
 }

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -43,17 +43,3 @@ windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }
 autocxx-bindgen = "0.71"
 autocxx-build = "0.27"
 cxx-build = "1"
-
-[lints.clippy]
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-wildcard_imports = "allow"
-enum_glob_use = "allow"
-unreadable_literal = "allow"
-multiple_crate_versions = "allow"
-significant_drop_tightening = "allow"
-must_use_candidate = "allow"

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2024"
 build = "build.rs"
 links = "idalib"
 include = [
-  "/build.rs",
-  "/src",
-  "/sdk/src/include",
-  "/sdk/src/lib/x64_linux_gcc_64/*.so",
-  "/sdk/src/lib/x64_mac_clang_64/*.dylib",
-  "/sdk/src/lib/arm64_mac_clang_64/*.dylib",
-  "/sdk/src/lib/x64_win_vc_64/*.lib",
+    "/build.rs",
+    "/src",
+    "/sdk/src/include",
+    "/sdk/src/lib/x64_linux_gcc_64/*.so",
+    "/sdk/src/lib/x64_mac_clang_64/*.dylib",
+    "/sdk/src/lib/arm64_mac_clang_64/*.dylib",
+    "/sdk/src/lib/x64_win_vc_64/*.lib",
 ]
 
 [dependencies]
@@ -43,3 +43,17 @@ windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }
 autocxx-bindgen = "0.71"
 autocxx-build = "0.27"
 cxx-build = "1"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+wildcard_imports = "allow"
+enum_glob_use = "allow"
+unreadable_literal = "allow"
+multiple_crate_versions = "allow"
+significant_drop_tightening = "allow"
+must_use_candidate = "allow"

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -42,3 +42,17 @@ windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }
 autocxx-bindgen = "0.71"
 autocxx-build = "0.27"
 cxx-build = "1"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+wildcard_imports = "allow"
+enum_glob_use = "allow"
+unreadable_literal = "allow"
+multiple_crate_versions = "allow"
+significant_drop_tightening = "allow"
+must_use_candidate = "allow"

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -26,7 +26,6 @@ include = [
 [dependencies]
 anyhow = "1"
 autocxx = "0.27"
-bitflags = "2"
 cxx = "1"
 thiserror = "1"
 

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -42,17 +42,3 @@ windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }
 autocxx-bindgen = "0.71"
 autocxx-build = "0.27"
 cxx-build = "1"
-
-[lints.clippy]
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-wildcard_imports = "allow"
-enum_glob_use = "allow"
-unreadable_literal = "allow"
-multiple_crate_versions = "allow"
-significant_drop_tightening = "allow"
-must_use_candidate = "allow"

--- a/idalib-sys/build.rs
+++ b/idalib-sys/build.rs
@@ -36,7 +36,7 @@ fn main() {
 
     let ffi_path = Path::new("src");
 
-    let mut builder = autocxx_build::Builder::new(ffi_path.join("lib.rs"), [&ffi_path, &*ida])
+    let mut builder = autocxx_build::Builder::new(ffi_path.join("lib.rs"), [ffi_path, &*ida])
         .extra_clang_args(
             #[cfg(target_os = "linux")]
             &["-std=c++17", "-D__LINUX__=1", "-D__EA64__=1"],

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -585,11 +585,7 @@ pub mod hexrays {
         }
 
         let mut failure = super::ffix::hexrays_error_t::default();
-        let result = super::ffix::idalib_hexrays_decompile_func(
-            f,
-            &mut failure as *mut _,
-            (flags as i32).into(),
-        );
+        let result = idalib_hexrays_decompile_func(f, &raw mut failure, (flags as i32).into());
 
         let code = HexRaysErrorCode::from(mem::transmute::<i32, merror_t>(failure.code));
 
@@ -1406,7 +1402,9 @@ pub mod ida {
         let mut minor = c_int(0);
         let mut build = c_int(0);
 
-        if unsafe { ffix::idalib_get_library_version(&mut major, &mut minor, &mut build) } {
+        if unsafe {
+            ffix::idalib_get_library_version(&raw mut major, &raw mut minor, &raw mut build)
+        } {
             Ok((major.0 as _, minor.0 as _, build.0 as _))
         } else {
             Err(IDAError::GetVersion)

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -1065,7 +1065,6 @@ pub mod insn {
 
     use super::ea_t;
     use super::ffi::decode_insn;
-
     pub use super::pod::insn_t;
 
     pub fn decode(ea: ea_t) -> Option<insn_t> {
@@ -1143,7 +1142,6 @@ pub mod processor {
     pub use super::ffix::{
         idalib_is_thumb_at, idalib_ph_id, idalib_ph_long_name, idalib_ph_short_name,
     };
-
     pub use super::idp as ids;
 }
 
@@ -1156,7 +1154,6 @@ pub mod segment {
         saRel512Bytes, saRel1024Bytes, saRel2048Bytes, saRelByte, saRelDble, saRelPage, saRelPara,
         saRelQword, saRelWord, segment_t,
     };
-
     pub use super::ffix::{
         idalib_segm_align, idalib_segm_bitness, idalib_segm_bytes, idalib_segm_name,
         idalib_segm_perm, idalib_segm_type,
@@ -1238,16 +1235,15 @@ pub mod name {
 
 pub mod ida {
     use std::env;
-    use std::ffi::{CStr, CString};
+    use std::ffi::CString;
     use std::path::Path;
     use std::ptr;
 
     use autocxx::prelude::*;
+    pub use ffi::auto_wait;
 
     use super::platform::is_main_thread;
     use super::{IDAError, ea_t, ffi, ffix};
-
-    pub use ffi::auto_wait;
 
     pub fn is_license_valid() -> bool {
         assert!(
@@ -1369,7 +1365,7 @@ pub mod ida {
         let path = CString::new(path.as_ref().to_string_lossy().as_ref()).map_err(IDAError::ffi)?;
         args.push(path);
 
-        let idalib0 = CStr::from_bytes_with_nul(b"idalib\0").map_err(IDAError::ffi)?;
+        let idalib0 = c"idalib";
 
         let argv = std::iter::once(idalib0.as_ptr())
             .chain(args.iter().map(|s| s.as_ptr()))

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -1330,7 +1330,7 @@ pub mod ida {
 
         let path = CString::new(path.as_ref().to_string_lossy().as_ref()).map_err(IDAError::ffi)?;
 
-        let res = unsafe { ffi::open_database(path.as_ptr(), auto_analysis, std::ptr::null()) };
+        let res = unsafe { ffi::open_database(path.as_ptr(), auto_analysis, ptr::null()) };
 
         if res != c_int(0) {
             Err(IDAError::OpenDb(res))

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -404,11 +404,11 @@ pub mod hexrays {
     }
 
     impl HexRaysError {
-        pub fn code(&self) -> HexRaysErrorCode {
+        pub const fn code(&self) -> HexRaysErrorCode {
             self.code
         }
 
-        pub fn address(&self) -> u64 {
+        pub const fn address(&self) -> u64 {
             self.addr
         }
 
@@ -460,11 +460,11 @@ pub mod hexrays {
     }
 
     impl HexRaysErrorCode {
-        pub fn is_ok(&self) -> bool {
+        pub const fn is_ok(&self) -> bool {
             matches!(self, Self::Ok | Self::Block)
         }
 
-        pub fn is_err(&self) -> bool {
+        pub const fn is_err(&self) -> bool {
             !self.is_ok()
         }
     }

--- a/idalib-sys/src/platform.rs
+++ b/idalib-sys/src/platform.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "linux")]
 pub fn is_main_thread() -> bool {
-    use libc::{c_long, getpid, syscall, SYS_gettid};
+    use libc::{SYS_gettid, c_long, getpid, syscall};
 
     unsafe { syscall(SYS_gettid) == getpid() as c_long }
 }
@@ -10,7 +10,9 @@ pub fn is_main_thread() -> bool {
     use objc::*;
 
     #[allow(unexpected_cfgs)]
-    unsafe { msg_send![class!(NSThread), isMainThread] }
+    unsafe {
+        msg_send![class!(NSThread), isMainThread]
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -22,17 +22,3 @@ idalib-sys = { version = "0.7", path = "../idalib-sys" }
 
 [build-dependencies]
 idalib-build = { version = "0.7", path = "../idalib-build" }
-
-[lints.clippy]
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-wildcard_imports = "allow"
-enum_glob_use = "allow"
-unreadable_literal = "allow"
-multiple_crate_versions = "allow"
-significant_drop_tightening = "allow"
-must_use_candidate = "allow"

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -22,3 +22,17 @@ idalib-sys = { version = "0.7", path = "../idalib-sys" }
 
 [build-dependencies]
 idalib-build = { version = "0.7", path = "../idalib-build" }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+wildcard_imports = "allow"
+enum_glob_use = "allow"
+unreadable_literal = "allow"
+multiple_crate_versions = "allow"
+significant_drop_tightening = "allow"
+must_use_candidate = "allow"

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -23,17 +23,3 @@ thiserror = "1"
 
 [build-dependencies]
 idalib-build = { version = "0.7", path = "../idalib-build" }
-
-[lints.clippy]
-all = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-wildcard_imports = "allow"
-enum_glob_use = "allow"
-unreadable_literal = "allow"
-multiple_crate_versions = "allow"
-significant_drop_tightening = "allow"
-must_use_candidate = "allow"

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -23,3 +23,17 @@ thiserror = "1"
 
 [build-dependencies]
 idalib-build = { version = "0.7", path = "../idalib-build" }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+wildcard_imports = "allow"
+enum_glob_use = "allow"
+unreadable_literal = "allow"
+multiple_crate_versions = "allow"
+significant_drop_tightening = "allow"
+must_use_candidate = "allow"

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -19,7 +19,6 @@ autocxx = "0.27"
 bitflags = "2"
 cxx = "1"
 idalib-sys = { version = "0.7", path = "../idalib-sys" }
-thiserror = "1"
 
 [build-dependencies]
 idalib-build = { version = "0.7", path = "../idalib-build" }

--- a/idalib/examples/comments_ls.rs
+++ b/idalib/examples/comments_ls.rs
@@ -71,8 +71,8 @@ fn main() -> anyhow::Result<()> {
     }
 
     println!("Testing find_text_iter()");
-    let results: Vec<_> = idb.find_text_iter("added by idalib").collect();
-    assert!(results.is_empty());
+    let len = idb.find_text_iter("added by idalib").count();
+    assert_eq!(len, 0);
 
     Ok(())
 }

--- a/idalib/examples/decrypt_strings.rs
+++ b/idalib/examples/decrypt_strings.rs
@@ -2,8 +2,8 @@
 // e8cdc0697748e702cf2916a2c5670325a891402ee38c98d91873a0f03e3f9025
 
 use idalib::idb::*;
-use idalib::insn::x86::{NN_lea, NN_mov};
 use idalib::insn::OperandType;
+use idalib::insn::x86::{NN_lea, NN_mov};
 use idalib::xref::{XRef, XRefQuery};
 
 const RCX: u16 = 1;
@@ -16,25 +16,21 @@ struct EncString {
 }
 
 impl EncString {
-    fn set_address(&mut self, address: u64) {
+    const fn set_address(&mut self, address: u64) {
         self.address = Some(address);
     }
 
-    fn set_size(&mut self, size: usize) {
+    const fn set_size(&mut self, size: usize) {
         self.size = Some(size);
     }
 
-    fn ready(self) -> bool {
+    const fn ready(self) -> bool {
         self.address.is_some() && self.size.is_some()
     }
 
     #[inline]
-    fn shrink_byte(b: u8) -> u8 {
-        if b > 0x7F {
-            b - 0x60
-        } else {
-            b
-        }
+    const fn shrink_byte(b: u8) -> u8 {
+        if b > 0x7F { b - 0x60 } else { b }
     }
 
     fn decrypt(&self, idb: &IDB) -> Option<String> {

--- a/idalib/examples/dump_ls.rs
+++ b/idalib/examples/dump_ls.rs
@@ -36,9 +36,9 @@ fn main() -> anyhow::Result<()> {
 
         println!("- name: {name:?}");
         println!("- bytes: {:x?}", &bytes[..bytes.len().min(16)]);
-        println!("- alignment: {:?}", align);
+        println!("- alignment: {align:?}");
         println!("- bitness: {}", 1 << (bitness + 4));
-        println!("- permissions: {:?}", perms);
+        println!("- permissions: {perms:?}");
     }
 
     println!("functions: {}", idb.function_count());

--- a/idalib/examples/strings_ls.rs
+++ b/idalib/examples/strings_ls.rs
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
     // get_address_by_index()
     assert!(idb.strings().get_address_by_index(len).is_none());
 
-    println!("\nTesting iterator:");
+    println!("\nTesting iterator");
     for (_address, _content) in idb.strings().iter() {
         /*
         println!(

--- a/idalib/src/decompiler.rs
+++ b/idalib/src/decompiler.rs
@@ -1,13 +1,12 @@
 use std::marker::PhantomData;
 
+pub use crate::ffi::hexrays::{HexRaysError, HexRaysErrorCode};
 use crate::ffi::hexrays::{
     cblock_iter, cblock_t, cfunc_t, cfuncptr_t, cinsn_t, idalib_hexrays_cblock_iter,
     idalib_hexrays_cblock_iter_next, idalib_hexrays_cblock_len, idalib_hexrays_cfunc_pseudocode,
     idalib_hexrays_cfuncptr_inner,
 };
 use crate::idb::IDB;
-
-pub use crate::ffi::hexrays::{HexRaysError, HexRaysErrorCode};
 
 pub struct CFunction<'a> {
     ptr: *mut cfunc_t,
@@ -67,11 +66,11 @@ impl<'a> CFunction<'a> {
         unsafe { idalib_hexrays_cfunc_pseudocode(self.ptr) }
     }
 
-    fn as_cfunc(&self) -> &cfunc_t {
+    const fn as_cfunc(&self) -> &cfunc_t {
         unsafe { self.ptr.as_ref().expect("valid pointer") }
     }
 
-    pub fn body(&self) -> CBlock<'_> {
+    pub const fn body(&self) -> CBlock<'_> {
         let cf = self.as_cfunc();
         let ptr = unsafe { cf.body.__bindgen_anon_1.cblock };
 

--- a/idalib/src/func.rs
+++ b/idalib/src/func.rs
@@ -31,11 +31,11 @@ pub struct BasicBlock<'a> {
 }
 
 impl<'a> BasicBlock<'a> {
-    fn as_range_t(&self) -> *const range_t {
+    const fn as_range_t(&self) -> *const range_t {
         self.block.cast()
     }
 
-    pub(crate) fn from_parts(ptr: *const qbasic_block_t, kind: fc_block_type_t) -> Self {
+    pub(crate) const fn from_parts(ptr: *const qbasic_block_t, kind: fc_block_type_t) -> Self {
         BasicBlock {
             block: ptr,
             kind,
@@ -63,35 +63,35 @@ impl<'a> BasicBlock<'a> {
         self.len() == 0
     }
 
-    pub fn is_normal(&self) -> bool {
+    pub const fn is_normal(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_normal)
     }
 
-    pub fn is_indjump(&self) -> bool {
+    pub const fn is_indjump(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_indjump)
     }
 
-    pub fn is_ret(&self) -> bool {
+    pub const fn is_ret(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_ret)
     }
 
-    pub fn is_cndret(&self) -> bool {
+    pub const fn is_cndret(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_cndret)
     }
 
-    pub fn is_noret(&self) -> bool {
+    pub const fn is_noret(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_noret)
     }
 
-    pub fn is_enoret(&self) -> bool {
+    pub const fn is_enoret(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_enoret)
     }
 
-    pub fn is_extern(&self) -> bool {
+    pub const fn is_extern(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_extern)
     }
 
-    pub fn is_error(&self) -> bool {
+    pub const fn is_error(&self) -> bool {
         matches!(self.kind, fc_block_type_t::fcb_error)
     }
 
@@ -176,11 +176,11 @@ impl<'a> Function<'a> {
         }
     }
 
-    pub(crate) fn as_ptr(&self) -> *mut func_t {
+    pub(crate) const fn as_ptr(&self) -> *mut func_t {
         self.ptr
     }
 
-    fn as_range_t(&self) -> *const range_t {
+    const fn as_range_t(&self) -> *const range_t {
         self.ptr.cast()
     }
 

--- a/idalib/src/func.rs
+++ b/idalib/src/func.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::mem;
 use std::pin::Pin;
 use std::ptr;
 
@@ -273,7 +272,7 @@ impl<'a> FunctionCFG<'a> {
     unsafe fn as_gdl_graph(&self) -> Option<&gdl_graph_t> {
         self.flow_chart
             .as_ref()
-            .map(|r| unsafe { mem::transmute::<&qflow_chart_t, &gdl_graph_t>(r) })
+            .map(|r| unsafe { &*ptr::from_ref::<qflow_chart_t>(r).cast::<gdl_graph_t>() })
     }
 
     pub fn block_by_id(&self, id: BasicBlockId) -> Option<BasicBlock<'_>> {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -457,7 +457,7 @@ impl IDB {
         }
     }
 
-    pub fn strings(&self) -> StringList<'_> {
+    pub const fn strings(&self) -> StringList<'_> {
         StringList::new(self)
     }
 

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -461,7 +461,7 @@ impl IDB {
         StringList::new(self)
     }
 
-    pub const fn names(&self) -> crate::name::NameList<'_> {
+    pub const fn names(&self) -> NameList<'_> {
         NameList::new(self)
     }
 

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
+use crate::bookmarks::Bookmarks;
+use crate::decompiler::CFunction;
 use crate::ffi::BADADDR;
 use crate::ffi::bytes::*;
 use crate::ffi::comments::{append_cmt, idalib_get_cmt, set_cmt};
@@ -20,9 +22,6 @@ use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text}
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
-
-use crate::bookmarks::Bookmarks;
-use crate::decompiler::CFunction;
 use crate::func::{Function, FunctionId};
 use crate::insn::{Insn, Register};
 use crate::meta::{Metadata, MetadataMut};
@@ -72,7 +71,7 @@ impl IDBOpenOptions {
         self
     }
 
-    pub fn save(&mut self, save: bool) -> &mut Self {
+    pub const fn save(&mut self, save: bool) -> &mut Self {
         self.save = save;
         self
     }
@@ -82,7 +81,7 @@ impl IDBOpenOptions {
         self
     }
 
-    pub fn auto_analyse(&mut self, auto_analyse: bool) -> &mut Self {
+    pub const fn auto_analyse(&mut self, auto_analyse: bool) -> &mut Self {
         self.auto_analyse = auto_analyse;
         self
     }
@@ -91,7 +90,7 @@ impl IDBOpenOptions {
         let mut args = Vec::new();
 
         if let Some(ftype) = self.ftype.as_ref() {
-            args.push(format!("-T{}", ftype));
+            args.push(format!("-T{ftype}"));
         }
 
         if let Some(idb_path) = self.idb.as_ref() {
@@ -146,7 +145,7 @@ impl IDB {
         &self.path
     }
 
-    pub fn save_on_close(&mut self, status: bool) {
+    pub const fn save_on_close(&mut self, status: bool) {
         self.save = status;
     }
 
@@ -162,15 +161,15 @@ impl IDB {
         make_signatures(only_pat)
     }
 
-    pub fn decompiler_available(&self) -> bool {
+    pub const fn decompiler_available(&self) -> bool {
         self.decompiler
     }
 
-    pub fn meta(&self) -> Metadata<'_> {
+    pub const fn meta(&self) -> Metadata<'_> {
         Metadata::new()
     }
 
-    pub fn meta_mut(&mut self) -> MetadataMut<'_> {
+    pub const fn meta_mut(&mut self) -> MetadataMut<'_> {
         MetadataMut::new()
     }
 
@@ -406,7 +405,7 @@ impl IDB {
         }
     }
 
-    pub fn bookmarks(&self) -> Bookmarks<'_> {
+    pub const fn bookmarks(&self) -> Bookmarks<'_> {
         Bookmarks::new(self)
     }
 
@@ -427,7 +426,7 @@ impl IDB {
         let mut cur = 0u64;
         std::iter::from_fn(move || {
             let found = self.find_text(cur, text.as_ref())?;
-            cur = self.find_defined(found).unwrap_or(BADADDR.into());
+            cur = self.find_defined(found).unwrap_or_else(|| BADADDR.into());
             Some(found)
         })
     }
@@ -462,7 +461,7 @@ impl IDB {
         StringList::new(self)
     }
 
-    pub fn names(&self) -> crate::name::NameList<'_> {
+    pub const fn names(&self) -> crate::name::NameList<'_> {
         NameList::new(self)
     }
 

--- a/idalib/src/insn.rs
+++ b/idalib/src/insn.rs
@@ -2,13 +2,11 @@ use std::mem;
 
 use bitflags::bitflags;
 
+use crate::Address;
 use crate::ffi::insn::insn_t;
 use crate::ffi::insn::op::*;
-use crate::ffi::util::{is_basic_block_end, is_call_insn, is_indirect_jump_insn, is_ret_insn};
-
 pub use crate::ffi::insn::{arm, mips, x86};
-
-use crate::Address;
+use crate::ffi::util::{is_basic_block_end, is_call_insn, is_indirect_jump_insn, is_ret_insn};
 
 pub type Register = u16;
 pub type Phrase = u16;
@@ -91,15 +89,15 @@ bitflags! {
 pub type InsnType = u16;
 
 impl Insn {
-    pub(crate) fn from_repr(inner: insn_t) -> Self {
+    pub(crate) const fn from_repr(inner: insn_t) -> Self {
         Self { inner }
     }
 
-    pub fn address(&self) -> Address {
+    pub const fn address(&self) -> Address {
         self.inner.ea
     }
 
-    pub fn itype(&self) -> InsnType {
+    pub const fn itype(&self) -> InsnType {
         self.inner.itype as _
     }
 
@@ -121,11 +119,11 @@ impl Insn {
             .unwrap_or(self.inner.ops.len())
     }
 
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.inner.size as _
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -151,23 +149,23 @@ impl Insn {
 }
 
 impl Operand {
-    pub fn flags(&self) -> OperandFlags {
+    pub const fn flags(&self) -> OperandFlags {
         OperandFlags::from_bits_retain(self.inner.flags)
     }
 
-    pub fn offb(&self) -> i8 {
+    pub const fn offb(&self) -> i8 {
         self.inner.offb
     }
 
-    pub fn offo(&self) -> i8 {
+    pub const fn offo(&self) -> i8 {
         self.inner.offo
     }
 
-    pub fn n(&self) -> usize {
+    pub const fn n(&self) -> usize {
         self.inner.n as _
     }
 
-    pub fn number(&self) -> usize {
+    pub const fn number(&self) -> usize {
         self.n()
     }
 
@@ -209,7 +207,7 @@ impl Operand {
         }
     }
 
-    pub fn outer_displacement(&self) -> Option<u64> {
+    pub const fn outer_displacement(&self) -> Option<u64> {
         if self.flags().contains(OperandFlags::OUTER_DISP) {
             Some(unsafe { self.inner.__bindgen_anon_2.value })
         } else {

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -91,9 +91,8 @@ pub mod segment;
 pub mod strings;
 pub mod xref;
 
-pub use idalib_sys as ffi;
-
 pub use ffi::IDAError;
+pub use idalib_sys as ffi;
 pub use idb::{IDB, IDBOpenOptions};
 pub use license::{LicenseId, is_valid_license, license_id};
 

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -104,7 +104,7 @@ pub struct AddressFlags<'a> {
 }
 
 impl<'a> AddressFlags<'a> {
-    pub(crate) fn new(flags: ffi::bytes::flags64_t) -> Self {
+    pub(crate) const fn new(flags: ffi::bytes::flags64_t) -> Self {
         Self {
             flags,
             _marker: PhantomData,
@@ -128,15 +128,15 @@ pub struct IDAVersion {
 }
 
 impl IDAVersion {
-    pub fn major(&self) -> i32 {
+    pub const fn major(&self) -> i32 {
         self.major
     }
 
-    pub fn minor(&self) -> i32 {
+    pub const fn minor(&self) -> i32 {
         self.minor
     }
 
-    pub fn build(&self) -> i32 {
+    pub const fn build(&self) -> i32 {
         self.build
     }
 }

--- a/idalib/src/license.rs
+++ b/idalib/src/license.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::ops::Deref;
 
-use crate::{ffi, init_library, IDAError};
+use crate::{IDAError, ffi, init_library};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LicenseId([u8; 6]);

--- a/idalib/src/meta.rs
+++ b/idalib/src/meta.rs
@@ -125,7 +125,7 @@ pub struct Metadata<'a> {
 }
 
 impl<'a> Metadata<'a> {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             _marker: PhantomData,
         }
@@ -846,7 +846,7 @@ pub struct MetadataMut<'a> {
 }
 
 impl<'a> MetadataMut<'a> {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             _marker: PhantomData,
         }

--- a/idalib/src/name.rs
+++ b/idalib/src/name.rs
@@ -3,13 +3,12 @@ use std::marker::PhantomData;
 
 use bitflags::bitflags;
 
+use crate::Address;
 use crate::ffi::BADADDR;
 use crate::ffi::name::{
     get_nlist_ea, get_nlist_idx, get_nlist_name, get_nlist_size, is_in_nlist, is_public_name,
     is_weak_name,
 };
-
-use crate::Address;
 use crate::idb::IDB;
 
 pub type NameIndex = usize;
@@ -66,7 +65,9 @@ impl<'a> NameList<'a> {
             return None;
         }
 
-        let name = unsafe { CStr::from_ptr(name) }.to_string_lossy().into_owned();
+        let name = unsafe { CStr::from_ptr(name) }
+            .to_string_lossy()
+            .into_owned();
 
         let mut properties = NameProperties::empty();
 

--- a/idalib/src/name.rs
+++ b/idalib/src/name.rs
@@ -35,7 +35,7 @@ pub struct Name {
 }
 
 impl Name {
-    pub fn address(&self) -> Address {
+    pub const fn address(&self) -> Address {
         self.address
     }
 
@@ -43,17 +43,17 @@ impl Name {
         &self.name
     }
 
-    pub fn is_public(&self) -> bool {
+    pub const fn is_public(&self) -> bool {
         self.properties.contains(NameProperties::PUBLIC)
     }
 
-    pub fn is_weak(&self) -> bool {
+    pub const fn is_weak(&self) -> bool {
         self.properties.contains(NameProperties::WEAK)
     }
 }
 
 impl<'a> NameList<'a> {
-    pub(crate) fn new(_: &'a IDB) -> Self {
+    pub(crate) const fn new(_: &'a IDB) -> Self {
         Self {
             _marker: PhantomData,
         }
@@ -112,7 +112,7 @@ impl<'a> NameList<'a> {
         self.len() == 0
     }
 
-    pub fn iter(&self) -> NameListIter<'_, 'a> {
+    pub const fn iter(&self) -> NameListIter<'_, 'a> {
         NameListIter {
             name_list: self,
             current_index: 0,

--- a/idalib/src/plugin.rs
+++ b/idalib/src/plugin.rs
@@ -3,9 +3,8 @@ use std::marker::PhantomData;
 use bitflags::bitflags;
 
 use crate::ffi::loader::*;
-use crate::idb::IDB;
-
 pub use crate::ffi::processor::ids as id;
+use crate::idb::IDB;
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -29,7 +28,7 @@ pub struct Plugin<'a> {
 }
 
 impl<'a> Plugin<'a> {
-    pub(crate) fn from_ptr(ptr: *const plugin_t) -> Self {
+    pub(crate) const fn from_ptr(ptr: *const plugin_t) -> Self {
         Self {
             ptr,
             _marker: PhantomData,

--- a/idalib/src/plugin.rs
+++ b/idalib/src/plugin.rs
@@ -36,7 +36,7 @@ impl<'a> Plugin<'a> {
     }
 
     pub fn run(&self, arg: usize) -> bool {
-        unsafe { run_plugin(&*self.ptr, arg) }
+        unsafe { run_plugin(&raw const *self.ptr, arg) }
     }
 
     pub fn version(&self) -> u64 {

--- a/idalib/src/processor.rs
+++ b/idalib/src/processor.rs
@@ -1,10 +1,9 @@
 use std::marker::PhantomData;
 
+use crate::Address;
+pub use crate::ffi::processor::ids as id;
 use crate::ffi::processor::*;
 use crate::idb::IDB;
-use crate::Address;
-
-pub use crate::ffi::processor::ids as id;
 
 pub struct Processor<'a> {
     ptr: *const processor_t,
@@ -17,313 +16,313 @@ pub type ProcessorId = i32;
 pub struct ProcessorFamily(ProcessorId);
 
 impl ProcessorFamily {
-    pub fn is_386(&self) -> bool {
+    pub const fn is_386(&self) -> bool {
         self.0 == id::PLFM_386 as _
     }
 
-    pub fn is_z80(&self) -> bool {
+    pub const fn is_z80(&self) -> bool {
         self.0 == id::PLFM_Z80 as _
     }
 
-    pub fn is_i860(&self) -> bool {
+    pub const fn is_i860(&self) -> bool {
         self.0 == id::PLFM_I860 as _
     }
 
-    pub fn is_8051(&self) -> bool {
+    pub const fn is_8051(&self) -> bool {
         self.0 == id::PLFM_8051 as _
     }
 
-    pub fn is_tms(&self) -> bool {
+    pub const fn is_tms(&self) -> bool {
         self.0 == id::PLFM_TMS as _
     }
 
-    pub fn is_6502(&self) -> bool {
+    pub const fn is_6502(&self) -> bool {
         self.0 == id::PLFM_6502 as _
     }
 
-    pub fn is_pdp(&self) -> bool {
+    pub const fn is_pdp(&self) -> bool {
         self.0 == id::PLFM_PDP as _
     }
 
-    pub fn is_68k(&self) -> bool {
+    pub const fn is_68k(&self) -> bool {
         self.0 == id::PLFM_68K as _
     }
 
-    pub fn is_java(&self) -> bool {
+    pub const fn is_java(&self) -> bool {
         self.0 == id::PLFM_JAVA as _
     }
 
-    pub fn is_6800(&self) -> bool {
+    pub const fn is_6800(&self) -> bool {
         self.0 == id::PLFM_6800 as _
     }
 
-    pub fn is_st7(&self) -> bool {
+    pub const fn is_st7(&self) -> bool {
         self.0 == id::PLFM_ST7 as _
     }
 
-    pub fn is_mc6812(&self) -> bool {
+    pub const fn is_mc6812(&self) -> bool {
         self.0 == id::PLFM_MC6812 as _
     }
 
-    pub fn is_mips(&self) -> bool {
+    pub const fn is_mips(&self) -> bool {
         self.0 == id::PLFM_MIPS as _
     }
 
-    pub fn is_arm(&self) -> bool {
+    pub const fn is_arm(&self) -> bool {
         self.0 == id::PLFM_ARM as _
     }
 
-    pub fn is_tmsc6(&self) -> bool {
+    pub const fn is_tmsc6(&self) -> bool {
         self.0 == id::PLFM_TMSC6 as _
     }
 
-    pub fn is_ppc(&self) -> bool {
+    pub const fn is_ppc(&self) -> bool {
         self.0 == id::PLFM_PPC as _
     }
 
-    pub fn is_80196(&self) -> bool {
+    pub const fn is_80196(&self) -> bool {
         self.0 == id::PLFM_80196 as _
     }
 
-    pub fn is_z8(&self) -> bool {
+    pub const fn is_z8(&self) -> bool {
         self.0 == id::PLFM_Z8 as _
     }
 
-    pub fn is_sh(&self) -> bool {
+    pub const fn is_sh(&self) -> bool {
         self.0 == id::PLFM_SH as _
     }
 
-    pub fn is_net(&self) -> bool {
+    pub const fn is_net(&self) -> bool {
         self.0 == id::PLFM_NET as _
     }
 
-    pub fn is_avr(&self) -> bool {
+    pub const fn is_avr(&self) -> bool {
         self.0 == id::PLFM_AVR as _
     }
 
-    pub fn is_h8(&self) -> bool {
+    pub const fn is_h8(&self) -> bool {
         self.0 == id::PLFM_H8 as _
     }
 
-    pub fn is_pic(&self) -> bool {
+    pub const fn is_pic(&self) -> bool {
         self.0 == id::PLFM_PIC as _
     }
 
-    pub fn is_sparc(&self) -> bool {
+    pub const fn is_sparc(&self) -> bool {
         self.0 == id::PLFM_SPARC as _
     }
 
-    pub fn is_alpha(&self) -> bool {
+    pub const fn is_alpha(&self) -> bool {
         self.0 == id::PLFM_ALPHA as _
     }
 
-    pub fn is_hppa(&self) -> bool {
+    pub const fn is_hppa(&self) -> bool {
         self.0 == id::PLFM_HPPA as _
     }
 
-    pub fn is_h8500(&self) -> bool {
+    pub const fn is_h8500(&self) -> bool {
         self.0 == id::PLFM_H8500 as _
     }
 
-    pub fn is_tricore(&self) -> bool {
+    pub const fn is_tricore(&self) -> bool {
         self.0 == id::PLFM_TRICORE as _
     }
 
-    pub fn is_dsp56k(&self) -> bool {
+    pub const fn is_dsp56k(&self) -> bool {
         self.0 == id::PLFM_DSP56K as _
     }
 
-    pub fn is_c166(&self) -> bool {
+    pub const fn is_c166(&self) -> bool {
         self.0 == id::PLFM_C166 as _
     }
 
-    pub fn is_st20(&self) -> bool {
+    pub const fn is_st20(&self) -> bool {
         self.0 == id::PLFM_ST20 as _
     }
 
-    pub fn is_ia64(&self) -> bool {
+    pub const fn is_ia64(&self) -> bool {
         self.0 == id::PLFM_IA64 as _
     }
 
-    pub fn is_i960(&self) -> bool {
+    pub const fn is_i960(&self) -> bool {
         self.0 == id::PLFM_I960 as _
     }
 
-    pub fn is_f2mc(&self) -> bool {
+    pub const fn is_f2mc(&self) -> bool {
         self.0 == id::PLFM_F2MC as _
     }
 
-    pub fn is_tms320c54(&self) -> bool {
+    pub const fn is_tms320c54(&self) -> bool {
         self.0 == id::PLFM_TMS320C54 as _
     }
 
-    pub fn is_tms320c55(&self) -> bool {
+    pub const fn is_tms320c55(&self) -> bool {
         self.0 == id::PLFM_TMS320C55 as _
     }
 
-    pub fn is_trimedia(&self) -> bool {
+    pub const fn is_trimedia(&self) -> bool {
         self.0 == id::PLFM_TRIMEDIA as _
     }
 
-    pub fn is_m32r(&self) -> bool {
+    pub const fn is_m32r(&self) -> bool {
         self.0 == id::PLFM_M32R as _
     }
 
-    pub fn is_nec_78k0(&self) -> bool {
+    pub const fn is_nec_78k0(&self) -> bool {
         self.0 == id::PLFM_NEC_78K0 as _
     }
 
-    pub fn is_nec_78k0s(&self) -> bool {
+    pub const fn is_nec_78k0s(&self) -> bool {
         self.0 == id::PLFM_NEC_78K0S as _
     }
 
-    pub fn is_m740(&self) -> bool {
+    pub const fn is_m740(&self) -> bool {
         self.0 == id::PLFM_M740 as _
     }
 
-    pub fn is_m7700(&self) -> bool {
+    pub const fn is_m7700(&self) -> bool {
         self.0 == id::PLFM_M7700 as _
     }
 
-    pub fn is_st9(&self) -> bool {
+    pub const fn is_st9(&self) -> bool {
         self.0 == id::PLFM_ST9 as _
     }
 
-    pub fn is_fr(&self) -> bool {
+    pub const fn is_fr(&self) -> bool {
         self.0 == id::PLFM_FR as _
     }
 
-    pub fn is_mc6816(&self) -> bool {
+    pub const fn is_mc6816(&self) -> bool {
         self.0 == id::PLFM_MC6816 as _
     }
 
-    pub fn is_m7900(&self) -> bool {
+    pub const fn is_m7900(&self) -> bool {
         self.0 == id::PLFM_M7900 as _
     }
 
-    pub fn is_tms320c3(&self) -> bool {
+    pub const fn is_tms320c3(&self) -> bool {
         self.0 == id::PLFM_TMS320C3 as _
     }
 
-    pub fn is_kr1878(&self) -> bool {
+    pub const fn is_kr1878(&self) -> bool {
         self.0 == id::PLFM_KR1878 as _
     }
 
-    pub fn is_ad218x(&self) -> bool {
+    pub const fn is_ad218x(&self) -> bool {
         self.0 == id::PLFM_AD218X as _
     }
 
-    pub fn is_oakdsp(&self) -> bool {
+    pub const fn is_oakdsp(&self) -> bool {
         self.0 == id::PLFM_OAKDSP as _
     }
 
-    pub fn is_tlcs900(&self) -> bool {
+    pub const fn is_tlcs900(&self) -> bool {
         self.0 == id::PLFM_TLCS900 as _
     }
 
-    pub fn is_c39(&self) -> bool {
+    pub const fn is_c39(&self) -> bool {
         self.0 == id::PLFM_C39 as _
     }
 
-    pub fn is_cr16(&self) -> bool {
+    pub const fn is_cr16(&self) -> bool {
         self.0 == id::PLFM_CR16 as _
     }
 
-    pub fn is_mn102l00(&self) -> bool {
+    pub const fn is_mn102l00(&self) -> bool {
         self.0 == id::PLFM_MN102L00 as _
     }
 
-    pub fn is_tms320c1x(&self) -> bool {
+    pub const fn is_tms320c1x(&self) -> bool {
         self.0 == id::PLFM_TMS320C1X as _
     }
 
-    pub fn is_nec_v850x(&self) -> bool {
+    pub const fn is_nec_v850x(&self) -> bool {
         self.0 == id::PLFM_NEC_V850X as _
     }
 
-    pub fn is_scr_adpt(&self) -> bool {
+    pub const fn is_scr_adpt(&self) -> bool {
         self.0 == id::PLFM_SCR_ADPT as _
     }
 
-    pub fn is_ebc(&self) -> bool {
+    pub const fn is_ebc(&self) -> bool {
         self.0 == id::PLFM_EBC as _
     }
 
-    pub fn is_msp430(&self) -> bool {
+    pub const fn is_msp430(&self) -> bool {
         self.0 == id::PLFM_MSP430 as _
     }
 
-    pub fn is_spu(&self) -> bool {
+    pub const fn is_spu(&self) -> bool {
         self.0 == id::PLFM_SPU as _
     }
 
-    pub fn is_dalvik(&self) -> bool {
+    pub const fn is_dalvik(&self) -> bool {
         self.0 == id::PLFM_DALVIK as _
     }
 
-    pub fn is_65c816(&self) -> bool {
+    pub const fn is_65c816(&self) -> bool {
         self.0 == id::PLFM_65C816 as _
     }
 
-    pub fn is_m16c(&self) -> bool {
+    pub const fn is_m16c(&self) -> bool {
         self.0 == id::PLFM_M16C as _
     }
 
-    pub fn is_arc(&self) -> bool {
+    pub const fn is_arc(&self) -> bool {
         self.0 == id::PLFM_ARC as _
     }
 
-    pub fn is_unsp(&self) -> bool {
+    pub const fn is_unsp(&self) -> bool {
         self.0 == id::PLFM_UNSP as _
     }
 
-    pub fn is_tms320c28(&self) -> bool {
+    pub const fn is_tms320c28(&self) -> bool {
         self.0 == id::PLFM_TMS320C28 as _
     }
 
-    pub fn is_dsp96k(&self) -> bool {
+    pub const fn is_dsp96k(&self) -> bool {
         self.0 == id::PLFM_DSP96K as _
     }
 
-    pub fn is_spc700(&self) -> bool {
+    pub const fn is_spc700(&self) -> bool {
         self.0 == id::PLFM_SPC700 as _
     }
 
-    pub fn is_ad2106x(&self) -> bool {
+    pub const fn is_ad2106x(&self) -> bool {
         self.0 == id::PLFM_AD2106X as _
     }
 
-    pub fn is_pic16(&self) -> bool {
+    pub const fn is_pic16(&self) -> bool {
         self.0 == id::PLFM_PIC16 as _
     }
 
-    pub fn is_s390(&self) -> bool {
+    pub const fn is_s390(&self) -> bool {
         self.0 == id::PLFM_S390 as _
     }
 
-    pub fn is_xtensa(&self) -> bool {
+    pub const fn is_xtensa(&self) -> bool {
         self.0 == id::PLFM_XTENSA as _
     }
 
-    pub fn is_riscv(&self) -> bool {
+    pub const fn is_riscv(&self) -> bool {
         self.0 == id::PLFM_RISCV as _
     }
 
-    pub fn is_rl78(&self) -> bool {
+    pub const fn is_rl78(&self) -> bool {
         self.0 == id::PLFM_RL78 as _
     }
 
-    pub fn is_rx(&self) -> bool {
+    pub const fn is_rx(&self) -> bool {
         self.0 == id::PLFM_RX as _
     }
 
-    pub fn is_wasm(&self) -> bool {
+    pub const fn is_wasm(&self) -> bool {
         self.0 == id::PLFM_WASM as _
     }
 }
 
 impl<'a> Processor<'a> {
-    pub(crate) fn from_ptr(ptr: *const processor_t) -> Self {
+    pub(crate) const fn from_ptr(ptr: *const processor_t) -> Self {
         Self {
             ptr,
             _marker: PhantomData,

--- a/idalib/src/segment.rs
+++ b/idalib/src/segment.rs
@@ -5,10 +5,10 @@ use std::pin::Pin;
 use autocxx::moveit::Emplace;
 use bitflags::bitflags;
 
+use crate::Address;
 use crate::ffi::range_t;
 use crate::ffi::segment::*;
 use crate::idb::IDB;
-use crate::Address;
 
 pub struct Segment<'a> {
     ptr: *mut segment_t,
@@ -28,16 +28,16 @@ bitflags! {
 }
 
 impl SegmentPermissions {
-    pub fn is_executable(&self) -> bool {
-        self.contains(SegmentPermissions::EXEC)
+    pub const fn is_executable(&self) -> bool {
+        self.contains(Self::EXEC)
     }
 
-    pub fn is_writable(&self) -> bool {
-        self.contains(SegmentPermissions::WRITE)
+    pub const fn is_writable(&self) -> bool {
+        self.contains(Self::WRITE)
     }
 
-    pub fn is_readable(&self) -> bool {
-        self.contains(SegmentPermissions::READ)
+    pub const fn is_readable(&self) -> bool {
+        self.contains(Self::READ)
     }
 }
 
@@ -62,63 +62,63 @@ pub enum SegmentAlignment {
 }
 
 impl SegmentAlignment {
-    pub fn is_abs(&self) -> bool {
+    pub const fn is_abs(&self) -> bool {
         matches!(self, Self::Abs)
     }
 
-    pub fn is_rel_byte(&self) -> bool {
+    pub const fn is_rel_byte(&self) -> bool {
         matches!(self, Self::RelByte)
     }
 
-    pub fn is_rel_word(&self) -> bool {
+    pub const fn is_rel_word(&self) -> bool {
         matches!(self, Self::RelWord)
     }
 
-    pub fn is_rel_para(&self) -> bool {
+    pub const fn is_rel_para(&self) -> bool {
         matches!(self, Self::RelPara)
     }
 
-    pub fn is_rel_page(&self) -> bool {
+    pub const fn is_rel_page(&self) -> bool {
         matches!(self, Self::RelPage)
     }
 
-    pub fn is_rel_dble(&self) -> bool {
+    pub const fn is_rel_dble(&self) -> bool {
         matches!(self, Self::RelDble)
     }
 
-    pub fn is_rel_4k(&self) -> bool {
+    pub const fn is_rel_4k(&self) -> bool {
         matches!(self, Self::Rel4K)
     }
 
-    pub fn is_group(&self) -> bool {
+    pub const fn is_group(&self) -> bool {
         matches!(self, Self::Group)
     }
 
-    pub fn is_rel_32_bytes(&self) -> bool {
+    pub const fn is_rel_32_bytes(&self) -> bool {
         matches!(self, Self::Rel32Bytes)
     }
 
-    pub fn is_rel_64_bytes(&self) -> bool {
+    pub const fn is_rel_64_bytes(&self) -> bool {
         matches!(self, Self::Rel64Bytes)
     }
 
-    pub fn is_rel_qword(&self) -> bool {
+    pub const fn is_rel_qword(&self) -> bool {
         matches!(self, Self::RelQword)
     }
 
-    pub fn is_rel_128_bytes(&self) -> bool {
+    pub const fn is_rel_128_bytes(&self) -> bool {
         matches!(self, Self::Rel128Bytes)
     }
 
-    pub fn is_rel_512_bytes(&self) -> bool {
+    pub const fn is_rel_512_bytes(&self) -> bool {
         matches!(self, Self::Rel512Bytes)
     }
 
-    pub fn is_rel_1024_bytes(&self) -> bool {
+    pub const fn is_rel_1024_bytes(&self) -> bool {
         matches!(self, Self::Rel1024Bytes)
     }
 
-    pub fn is_rel_2048_bytes(&self) -> bool {
+    pub const fn is_rel_2048_bytes(&self) -> bool {
         matches!(self, Self::Rel2048Bytes)
     }
 }
@@ -141,7 +141,7 @@ pub enum SegmentType {
 }
 
 impl SegmentType {
-    pub fn is_normal(&self) -> bool {
+    pub const fn is_normal(&self) -> bool {
         matches!(self, Self::NORM)
     }
 
@@ -149,7 +149,7 @@ impl SegmentType {
         self.is_normal()
     }
 
-    pub fn is_extern(&self) -> bool {
+    pub const fn is_extern(&self) -> bool {
         matches!(self, Self::XTRN)
     }
 
@@ -157,15 +157,15 @@ impl SegmentType {
         self.is_extern()
     }
 
-    pub fn is_code(&self) -> bool {
+    pub const fn is_code(&self) -> bool {
         matches!(self, Self::CODE)
     }
 
-    pub fn is_data(&self) -> bool {
+    pub const fn is_data(&self) -> bool {
         matches!(self, Self::DATA)
     }
 
-    pub fn is_import(&self) -> bool {
+    pub const fn is_import(&self) -> bool {
         matches!(self, Self::IMP)
     }
 
@@ -173,7 +173,7 @@ impl SegmentType {
         self.is_import()
     }
 
-    pub fn is_group(&self) -> bool {
+    pub const fn is_group(&self) -> bool {
         matches!(self, Self::GRP)
     }
 
@@ -181,27 +181,27 @@ impl SegmentType {
         self.is_group()
     }
 
-    pub fn is_bss(&self) -> bool {
+    pub const fn is_bss(&self) -> bool {
         matches!(self, Self::BSS)
     }
 
-    pub fn is_null(&self) -> bool {
+    pub const fn is_null(&self) -> bool {
         matches!(self, Self::NULL)
     }
 
-    pub fn is_absym(&self) -> bool {
+    pub const fn is_absym(&self) -> bool {
         matches!(self, Self::ABSSYM)
     }
 
-    pub fn is_comm(&self) -> bool {
+    pub const fn is_comm(&self) -> bool {
         matches!(self, Self::COMM)
     }
 
-    pub fn is_imem(&self) -> bool {
+    pub const fn is_imem(&self) -> bool {
         matches!(self, Self::IMEM)
     }
 
-    pub fn is_undefined(&self) -> bool {
+    pub const fn is_undefined(&self) -> bool {
         matches!(self, Self::UNDF)
     }
 
@@ -220,7 +220,7 @@ impl<'a> Segment<'a> {
         }
     }
 
-    fn as_range_t(&self) -> *const range_t {
+    const fn as_range_t(&self) -> *const range_t {
         self.ptr.cast()
     }
 
@@ -247,11 +247,7 @@ impl<'a> Segment<'a> {
     pub fn name(&self) -> Option<String> {
         let name = unsafe { idalib_segm_name(self.ptr) }.ok()?;
 
-        if name.is_empty() {
-            None
-        } else {
-            Some(name)
-        }
+        if name.is_empty() { None } else { Some(name) }
     }
 
     pub fn alignment(&self) -> SegmentAlignment {

--- a/idalib/src/segment.rs
+++ b/idalib/src/segment.rs
@@ -145,7 +145,7 @@ impl SegmentType {
         matches!(self, Self::NORM)
     }
 
-    pub fn is_norm(&self) -> bool {
+    pub const fn is_norm(&self) -> bool {
         self.is_normal()
     }
 
@@ -153,7 +153,7 @@ impl SegmentType {
         matches!(self, Self::XTRN)
     }
 
-    pub fn is_xtrn(&self) -> bool {
+    pub const fn is_xtrn(&self) -> bool {
         self.is_extern()
     }
 
@@ -169,7 +169,7 @@ impl SegmentType {
         matches!(self, Self::IMP)
     }
 
-    pub fn is_imp(&self) -> bool {
+    pub const fn is_imp(&self) -> bool {
         self.is_import()
     }
 
@@ -177,7 +177,7 @@ impl SegmentType {
         matches!(self, Self::GRP)
     }
 
-    pub fn is_grp(&self) -> bool {
+    pub const fn is_grp(&self) -> bool {
         self.is_group()
     }
 
@@ -205,7 +205,7 @@ impl SegmentType {
         matches!(self, Self::UNDF)
     }
 
-    pub fn is_undf(&self) -> bool {
+    pub const fn is_undf(&self) -> bool {
         self.is_undefined()
     }
 }

--- a/idalib/src/strings.rs
+++ b/idalib/src/strings.rs
@@ -1,14 +1,13 @@
 use std::marker::PhantomData;
 
+use crate::Address;
+use crate::ffi::BADADDR;
 use crate::ffi::bytes::idalib_get_bytes;
 use crate::ffi::strings::{
     build_strlist, clear_strlist, get_strlist_qty, idalib_get_strlist_item_addr,
     idalib_get_strlist_item_length,
 };
-use crate::ffi::BADADDR;
-
 use crate::idb::IDB;
-use crate::Address;
 
 pub type StringIndex = usize;
 
@@ -17,7 +16,7 @@ pub struct StringList<'a> {
 }
 
 impl<'a> StringList<'a> {
-    pub(crate) fn new(_: &'a IDB) -> Self {
+    pub(crate) const fn new(_: &'a IDB) -> Self {
         Self {
             _marker: PhantomData,
         }
@@ -69,7 +68,7 @@ impl<'a> StringList<'a> {
         self.len() == 0
     }
 
-    pub fn iter(&self) -> StringListIter<'_, 'a> {
+    pub const fn iter(&self) -> StringListIter<'_, 'a> {
         StringListIter {
             string_list: self,
             current_index: 0,
@@ -94,7 +93,7 @@ impl<'s, 'a> Iterator for StringListIter<'s, 'a> {
 
             if let (Some(addr), Some(string)) = (addr, string) {
                 return Some((addr, string));
-            };
+            }
             // skip invalid strings, such as:
             // - the index became invalid, such as if a string was undefined
             // - the string failed to decode (today: not UTF-8)

--- a/idalib/src/xref.rs
+++ b/idalib/src/xref.rs
@@ -113,7 +113,7 @@ impl<'a> XRef<'a> {
         self.inner.iscode
     }
 
-    pub fn is_data(&self) -> bool {
+    pub const fn is_data(&self) -> bool {
         !self.is_code()
     }
 
@@ -124,7 +124,7 @@ impl<'a> XRef<'a> {
     pub fn next_to(&self) -> Option<Self> {
         let mut curr = self.clone();
 
-        let found = unsafe { xrefblk_t_next_to(&mut curr.inner as *mut _) };
+        let found = unsafe { xrefblk_t_next_to(&raw mut curr.inner) };
 
         if found { Some(curr) } else { None }
     }
@@ -132,7 +132,7 @@ impl<'a> XRef<'a> {
     pub fn next_from(&self) -> Option<Self> {
         let mut curr = self.clone();
 
-        let found = unsafe { xrefblk_t_next_from(&mut curr.inner as *mut _) };
+        let found = unsafe { xrefblk_t_next_from(&raw mut curr.inner) };
 
         if found { Some(curr) } else { None }
     }

--- a/idalib/src/xref.rs
+++ b/idalib/src/xref.rs
@@ -3,12 +3,11 @@ use std::mem;
 
 use bitflags::bitflags;
 
+use crate::Address;
 use crate::ffi::xref::cref_t::*;
 use crate::ffi::xref::dref_t::*;
 use crate::ffi::xref::*;
-
 use crate::idb::IDB;
-use crate::Address;
 
 pub struct XRef<'a> {
     inner: xrefblk_t,
@@ -80,7 +79,7 @@ bitflags! {
 }
 
 impl<'a> XRef<'a> {
-    pub(crate) fn from_repr(inner: xrefblk_t) -> Self {
+    pub(crate) const fn from_repr(inner: xrefblk_t) -> Self {
         Self {
             inner,
             _marker: PhantomData,
@@ -95,7 +94,7 @@ impl<'a> XRef<'a> {
         self.inner.to.into()
     }
 
-    pub fn flags(&self) -> XRefFlags {
+    pub const fn flags(&self) -> XRefFlags {
         let flags = self.inner.type_ & !(XREF_MASK as u8);
         XRefFlags::from_bits_retain(flags)
     }
@@ -110,7 +109,7 @@ impl<'a> XRef<'a> {
         }
     }
 
-    pub fn is_code(&self) -> bool {
+    pub const fn is_code(&self) -> bool {
         self.inner.iscode
     }
 
@@ -118,7 +117,7 @@ impl<'a> XRef<'a> {
         !self.is_code()
     }
 
-    pub fn is_user_defined(&self) -> bool {
+    pub const fn is_user_defined(&self) -> bool {
         self.inner.user
     }
 
@@ -127,11 +126,7 @@ impl<'a> XRef<'a> {
 
         let found = unsafe { xrefblk_t_next_to(&mut curr.inner as *mut _) };
 
-        if found {
-            Some(curr)
-        } else {
-            None
-        }
+        if found { Some(curr) } else { None }
     }
 
     pub fn next_from(&self) -> Option<Self> {
@@ -139,10 +134,6 @@ impl<'a> XRef<'a> {
 
         let found = unsafe { xrefblk_t_next_from(&mut curr.inner as *mut _) };
 
-        if found {
-            Some(curr)
-        } else {
-            None
-        }
+        if found { Some(curr) } else { None }
     }
 }


### PR DESCRIPTION
I have fixed some clippy lints and applied some minor adjustments to the code. I've run tests and checked that no semver update is required, and I'm reasonably certain that my changes didn't break anything, but please see if they make sense.

You could catch some other clippy recommendations by adding something like this in `Cargo.toml`:
```toml
[lints.clippy]
all = { level = "warn", priority = -1 }
pedantic = { level = "warn", priority = -1 }
nursery = { level = "warn", priority = -1 }
cargo = { level = "warn", priority = -1 }
missing_errors_doc = "allow"
missing_panics_doc = "allow"
wildcard_imports = "allow"
enum_glob_use = "allow"
unreadable_literal = "allow"
multiple_crate_versions = "allow"
significant_drop_tightening = "allow"
must_use_candidate = "allow"
```

PS. My IDE (RustRover) has decided to introduce some formatting changes as well... If you don't like them, let me know and I'll undo them.