### PR TITLE
Add `set_name()` as `IDB::set_name()`

### DIFF
--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -384,6 +384,8 @@ include_cpp! {
     generate!("is_in_nlist")
     generate!("is_public_name")
     generate!("is_weak_name")
+    generate!("set_name")
+
 }
 
 pub mod hexrays {
@@ -1234,7 +1236,7 @@ pub mod nalt {
 pub mod name {
     pub use super::ffi::{
         get_nlist_ea, get_nlist_idx, get_nlist_name, get_nlist_size, is_in_nlist, is_public_name,
-        is_weak_name,
+        is_weak_name, set_name,
     };
 }
 

--- a/idalib/src/name.rs
+++ b/idalib/src/name.rs
@@ -26,6 +26,29 @@ bitflags! {
     }
 }
 
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct SetNameFlags: i32 {
+        const SN_CHECK        = 0x00;
+        const SN_NOCHECK      = 0x01;
+        const SN_PUBLIC       = 0x02;
+        const SN_NON_PUBLIC   = 0x04;
+        const SN_WEAK         = 0x08;
+        const SN_NON_WEAK     = 0x10;
+        const SN_AUTO         = 0x20;
+        const SN_NON_AUTO     = 0x40;
+        const SN_NOLIST       = 0x80;
+        const SN_NOWARN       = 0x100;
+        const SN_LOCAL        = 0x200;
+        const SN_IDBENC       = 0x400;
+        const SN_FORCE        = 0x800;
+        const SN_NODUMMY      = 0x1000;
+        const SN_DELTAIL      = 0x2000;
+        const SN_MULTI        = 0x4000;
+        const SN_MULTI_FORCE  = 0x8000;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Name {
     address: Address,
@@ -66,7 +89,9 @@ impl<'a> NameList<'a> {
             return None;
         }
 
-        let name = unsafe { CStr::from_ptr(name) }.to_string_lossy().into_owned();
+        let name = unsafe { CStr::from_ptr(name) }
+            .to_string_lossy()
+            .into_owned();
 
         let mut properties = NameProperties::empty();
 


### PR DESCRIPTION
Add `set_name()` and `IDB::set_name()`.

Went by the C++ API rather that use `idb.names().set(...)` or some equivalent.

I don't want to hijack the PR but I have an interest in seeing `create_data()` making it into the bindings. This is not necessarily easy due to the introduction of `tid_t`and therefore types which `idalib` doesn't handle yet.  Is this something we are interested in pursuing at some point? In the meantime I"ll probably roll with my own fork that neuters that parameter.

Thanks as always! 🦭

> I've now seen #39 so will wait until that makes it into `master`.