### PR TITLE
Update version to 0.8 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bindings are only guaranteed compatible with the latest official IDA Pro/SDK
 release. See the table below for compatibility:
 
 | IDA Pro version | Latest compatible idalib |
-|-----------------|--------------------------|
+| --------------- | ------------------------ |
 | v9.3            | 0.8.0                    |
 | v9.2            | 0.7.2                    |
 | v9.1            | 0.6.1                    |

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -91,8 +91,9 @@ pub mod segment;
 pub mod strings;
 pub mod xref;
 
-pub use ffi::IDAError;
 pub use idalib_sys as ffi;
+
+pub use ffi::IDAError;
 pub use idb::{IDB, IDBOpenOptions};
 pub use license::{LicenseId, is_valid_license, license_id};
 


### PR DESCRIPTION
Just a minor fix to the documentation for the 0.8 release.