### PR TITLE
build(windows): define _CRT_USE_BUILTIN_OFFSETOF to avoid usage of reinterpret_cast in offsetof macro

### DIFF
--- a/idalib-sys/build.rs
+++ b/idalib-sys/build.rs
@@ -16,7 +16,12 @@ fn configure_and_generate(builder: BindgenBuilder, ida: &Path, output: impl AsRe
             #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
             &["-std=c++17", "-D__MACOS__=1", "-D__EA64__=1"],
             #[cfg(target_os = "windows")]
-            &["-std=c++17", "-D__NT__=1", "-D__EA64__=1"],
+            &[
+                "-std=c++17",
+                "-D__NT__=1",
+                "-D__EA64__=1",
+                "-D_CRT_USE_BUILTIN_OFFSETOF",
+            ],
         )
         .respect_cxx_access_specs(true)
         .generate()
@@ -45,7 +50,12 @@ fn main() {
             #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
             &["-std=c++17", "-D__MACOS__=1", "-D__EA64__=1"],
             #[cfg(target_os = "windows")]
-            &["-std=c++17", "-D__NT__=1", "-D__EA64__=1"],
+            &[
+                "-std=c++17",
+                "-D__NT__=1",
+                "-D__EA64__=1",
+                "-D_CRT_USE_BUILTIN_OFFSETOF",
+            ],
         )
         .build()
         .expect("parsed correctly");
@@ -143,7 +153,6 @@ fn main() {
     }
 
     let hexrays = autocxx_bindgen::builder()
-        .header(ffi_path.join("fixups.h").to_str().expect("path is valid string"))
         .header(ida.join("pro.h").to_str().expect("path is valid string"))
         .header(
             ida.join("hexrays.hpp")

--- a/idalib-sys/src/fixups.h
+++ b/idalib-sys/src/fixups.h
@@ -1,6 +1,0 @@
-#include <cstddef>
-
-#if defined(_MSC_VER) && defined(__clang__)
-#undef offsetof
-#define offsetof(t, m) __builtin_offsetof(t, m)
-#endif

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -54,8 +54,6 @@ impl IDAError {
 }
 
 include_cpp! {
-    // NOTE: this fixes compilation issues on Windows when cross-compiling
-    #include "fixups.h"
     // NOTE: this fixes autocxx's inability to detect ea_t, optype_t as POD...
     #include "types.h"
 


### PR DESCRIPTION
See https://github.com/idalib-rs/idalib/issues/60. I tested it on the environment in which I had previously reproduced the issue. Build is successful from both `x64_x86 Cross Tools Command Prompt` and `x64 Native Tools Command Prompt`.