### PR TITLE
IDA v9.3 SP1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0 (2026-04-05)
+
+Compatibility release for IDA 9.3sp1.
+
 ## 0.8.1 (2026-02-21)
 
 Bugfix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-## 0.9.0 (2026-04-06)
-
-Compatibility release for IDA 9.3sp1.
+## 0.9.0 (2026-04-14)
 
 Features:
+- Compatibility with IDA 9.3sp1.
 - Support for writing Rust-based plugins.
 
 ## 0.8.1 (2026-02-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 0.9.0 (2026-04-05)
+## 0.9.0 (2026-04-06)
 
 Compatibility release for IDA 9.3sp1.
+
+Features:
+- Support for writing Rust-based plugins.
 
 ## 0.8.1 (2026-02-21)
 
@@ -11,7 +14,7 @@ Bugfix:
 
 ## 0.8.0 (2026-02-20)
 
-- Compatibility release for IDA 9.3 (contributor:
+Compatibility release for IDA 9.3 (contributor:
   [@yeggor](https://github.com/yeggor)).
 
 ## 0.7.2 (2025-09-16)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 members = [
   "idalib",
   "idalib-build",
+  "idalib-macros",
+  "idalib-sys",
+  "examples/*",
+]
+default-members = [
+  "idalib",
+  "idalib-build",
   "idalib-sys",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # idalib
 
 [![crates.io](https://img.shields.io/crates/v/idalib)](https://crates.io/crates/idalib)
-[![documentation](https://img.shields.io/badge/documentation-0.8.1%2B9.3.260213-blue?link=https%3A%2F%2Fidalib.rs%2Fidalib)](https://idalib.rs/idalib/)
+[![documentation](https://img.shields.io/badge/documentation-0.9.0%2B9.3.260327-blue?link=https%3A%2F%2Fidalib.rs%2Fidalib)](https://idalib.rs/idalib/)
 [![license](https://img.shields.io/crates/l/idalib)](https://github.com/idalib-rs/idalib)
 [![crates.io downloads](https://img.shields.io/crates/d/idalib)](https://crates.io/crates/idalib)
 
@@ -17,6 +17,7 @@ release. See the table below for compatibility:
 
 | IDA Pro version | Latest compatible idalib |
 | --------------- | ------------------------ |
+| v9.3sp1         | 0.9.0                    |
 | v9.3            | 0.8.1                    |
 | v9.2            | 0.7.2                    |
 | v9.1            | 0.6.1                    |
@@ -61,10 +62,10 @@ name = "example-analyser"
 # ...
 
 [dependencies]
-idalib = "0.8"
+idalib = "0.9"
 
 [build-dependencies]
-idalib-build = "0.8"
+idalib-build = "0.9"
 ```
 
 `build.rs`:

--- a/examples/basic-plugin/Cargo.toml
+++ b/examples/basic-plugin/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "basic-plugin"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "basic_plugin"
+crate-type = ["cdylib"]
+
+[dependencies]
+idalib = { version = "0.8", path = "../../idalib", features = ["plugin"] }
+
+[build-dependencies]
+idalib-build = { version = "0.8", path = "../../idalib-build" }

--- a/examples/basic-plugin/Cargo.toml
+++ b/examples/basic-plugin/Cargo.toml
@@ -8,7 +8,7 @@ name = "basic_plugin"
 crate-type = ["cdylib"]
 
 [dependencies]
-idalib = { version = "0.8", path = "../../idalib", features = ["plugin"] }
+idalib = { version = "0.9", path = "../../idalib", features = ["plugin"] }
 
 [build-dependencies]
-idalib-build = { version = "0.8", path = "../../idalib-build" }
+idalib-build = { version = "0.9", path = "../../idalib-build" }

--- a/examples/basic-plugin/build.rs
+++ b/examples/basic-plugin/build.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, ida_path, idalib_path) = idalib_build::idalib_install_paths_with(false);
+    if !ida_path.exists() || !idalib_path.exists() {
+        idalib_build::configure_idasdk_linkage();
+    } else {
+        idalib_build::configure_linkage()?;
+    }
+    Ok(())
+}

--- a/examples/basic-plugin/src/lib.rs
+++ b/examples/basic-plugin/src/lib.rs
@@ -1,0 +1,30 @@
+use idalib::{IDA, IDAError, IDAPlugin, IDB, plugin};
+
+struct BasicPlugin {
+    run_count: usize,
+}
+
+#[plugin(
+    name = "basic plugin",
+    comment = "this is a basic plugin written in Rust",
+    help = "this plugin does nothing useful",
+    hotkey = "Ctrl-Shift-B",
+    kind = resident,
+)]
+impl IDAPlugin for BasicPlugin {
+    fn init(ida: &mut IDA, _idb: &mut IDB) -> Result<Self, IDAError> {
+        ida.msg("[basic-plugin] init\n")?;
+        Ok(BasicPlugin { run_count: 0 })
+    }
+
+    fn run(&mut self, ida: &mut IDA, _idb: &mut IDB, _arg: usize) -> Result<(), IDAError> {
+        self.run_count += 1;
+        ida.msg(&format!("[basic-plugin] run (count: {})\n", self.run_count))?;
+        Ok(())
+    }
+
+    fn term(&mut self, ida: &mut IDA, _idb: &mut IDB) -> Result<(), IDAError> {
+        ida.msg("[basic-plugin] term\n")?;
+        Ok(())
+    }
+}

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -8,7 +8,7 @@
     "idaVersions": ["9.0", "9.1", "9.2", "9.3"],
     "description" : "Idiomatic Rust bindings to IDA SDK",
     "license": "MIT OR Apache-2.0",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "urls": {
       "repository": "https://github.com/idalib-rs/idalib",
       "documentation": "https://idalib.rs"

--- a/idalib-build/Cargo.toml
+++ b/idalib-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idalib-build"
 authors = ["Sam L. Thomas <st@xv.ax>", "Yegor Vasilenko <yv@yegor.cc>", "Marco Ivaldi <raptor@0xdeadbeef.info>"]
-version = "0.8.1+9.3.260213"
+version = "0.9.0+9.3.260327"
 description = "Idiomatic bindings to IDA SDK"
 repository = "https://github.com/idalib-rs/idalib"
 documentation = "https://idalib.rs/idalib_build"
@@ -15,4 +15,4 @@ build = "build.rs"
 
 [dependencies]
 anyhow = "1"
-idalib-sys = { version = "0.8", path = "../idalib-sys" }
+idalib-sys = { version = "0.9", path = "../idalib-sys" }

--- a/idalib-build/src/lib.rs
+++ b/idalib-build/src/lib.rs
@@ -25,21 +25,21 @@ pub fn idalib_sdk_paths_with(check: bool) -> (PathBuf, PathBuf, PathBuf, PathBuf
     }
 
     let (stubs_path, idalib, ida) = if cfg!(target_os = "linux") {
-        let path = sdk_path.join("lib/x64_linux_gcc_64");
+        let path = sdk_path.join("lib/x64_linux_64");
         let idalib = path.join("libidalib.so");
         let ida = path.join("libida.so");
         (path, idalib, ida)
     } else if cfg!(target_os = "macos") {
         let path = if cfg!(target_arch = "x86_64") {
-            sdk_path.join("lib/x64_mac_clang_64")
+            sdk_path.join("lib/x64_mac_64")
         } else {
-            sdk_path.join("lib/arm64_mac_clang_64")
+            sdk_path.join("lib/arm64_mac_64")
         };
         let idalib = path.join("libidalib.dylib");
         let ida = path.join("libida.dylib");
         (path, idalib, ida)
     } else if cfg!(target_os = "windows") {
-        let path = sdk_path.join("lib\\x64_win_vc_64");
+        let path = sdk_path.join("lib\\x64_win_64");
         let idalib = path.join("idalib.lib");
         let ida = path.join("ida.lib");
         (path, idalib, ida)

--- a/idalib-macros/Cargo.toml
+++ b/idalib-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "idalib"
+name = "idalib-macros"
 authors = ["Sam L. Thomas <st@xv.ax>", "Yegor Vasilenko <yv@yegor.cc>", "Marco Ivaldi <raptor@0xdeadbeef.info>"]
 version = "0.9.0+9.3.260327"
 description = "Idiomatic bindings to IDA SDK"
@@ -9,22 +9,12 @@ homepage = "https://idalib.rs"
 keywords = ["reverse-engineering", "ida", "ida-pro", "idalib"]
 categories = ["security"]
 license = "MIT OR Apache-2.0"
-readme = "../README.md"
 edition = "2024"
-build = "build.rs"
 
-[features]
-plugin = ["dep:idalib-macros"]
-default = []
+[lib]
+proc-macro = true
 
 [dependencies]
-anyhow = "1"
-autocxx = "0.27"
-bitflags = "2"
-cxx = "1"
-idalib-macros = { version = "0.9", path = "../idalib-macros", optional = true }
-idalib-sys = { version = "0.9", path = "../idalib-sys" }
-thiserror = "1"
-
-[build-dependencies]
-idalib-build = { version = "0.9", path = "../idalib-build" }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/idalib-macros/src/lib.rs
+++ b/idalib-macros/src/lib.rs
@@ -1,0 +1,234 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Expr, ExprLit, ItemImpl, Lit, LitCStr, Token, parse_macro_input};
+
+const PLUGIN_MOD: i32 = 0x0001;
+const PLUGIN_UNL: i32 = 0x0008;
+const PLUGIN_FIX: i32 = 0x0080;
+const PLUGIN_MULTI: i32 = 0x0100;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum PluginKind {
+    #[default]
+    Default,
+    Resident,
+    Oneshot,
+}
+
+struct PluginArgs {
+    name: String,
+    comment: Option<String>,
+    help: Option<String>,
+    hotkey: Option<String>,
+    version: Option<i32>,
+    kind: PluginKind,
+}
+
+impl Parse for PluginArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut name = None;
+        let mut comment = None;
+        let mut help = None;
+        let mut hotkey = None;
+        let mut version = None;
+        let mut kind = PluginKind::Default;
+
+        let pairs = Punctuated::<syn::MetaNameValue, Token![,]>::parse_terminated(input)?;
+        for pair in pairs {
+            let Some(key) = pair.path.get_ident() else {
+                return Err(syn::Error::new_spanned(pair.path, "expected identifier"));
+            };
+
+            if key == "name" {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = pair.value
+                {
+                    name = Some(s.value());
+                    continue;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        pair.value,
+                        "expected string literal",
+                    ));
+                }
+            }
+
+            if key == "comment" {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = pair.value
+                {
+                    comment = Some(s.value());
+                    continue;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        pair.value,
+                        "expected string literal",
+                    ));
+                }
+            }
+
+            if key == "help" {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = pair.value
+                {
+                    help = Some(s.value());
+                    continue;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        pair.value,
+                        "expected string literal",
+                    ));
+                }
+            }
+
+            if key == "hotkey" {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = pair.value
+                {
+                    hotkey = Some(s.value());
+                    continue;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        pair.value,
+                        "expected string literal",
+                    ));
+                }
+            }
+
+            if key == "version" {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Int(i), ..
+                }) = pair.value
+                {
+                    version = Some(i.base10_parse()?);
+                    continue;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        pair.value,
+                        "expected integer literal",
+                    ));
+                }
+            }
+
+            if key == "kind" {
+                if let Expr::Path(ref path) = pair.value
+                    && let Some(ident) = path.path.get_ident()
+                {
+                    kind = if ident == "default" {
+                        PluginKind::Default
+                    } else if ident == "resident" {
+                        PluginKind::Resident
+                    } else if ident == "oneshot" {
+                        PluginKind::Oneshot
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            ident,
+                            format!(
+                                "unknown kind `{ident}`, expected `default`, `resident`, or `oneshot`"
+                            ),
+                        ));
+                    };
+                    continue;
+                } else {
+                    return Err(syn::Error::new_spanned(
+                        &pair.value,
+                        "expected identifier: `default`, `resident`, or `oneshot`",
+                    ));
+                }
+            }
+
+            return Err(syn::Error::new_spanned(
+                &pair.path,
+                format!("unknown attribute `{key}`"),
+            ));
+        }
+
+        Ok(Self {
+            name: name.ok_or_else(|| syn::Error::new(input.span(), "missing `name` attribute"))?,
+            comment,
+            help,
+            hotkey,
+            version,
+            kind,
+        })
+    }
+}
+
+fn make_cstr_literal(s: &str) -> LitCStr {
+    let cstring = std::ffi::CString::new(s).expect("string contains null byte");
+    LitCStr::new(&cstring, Span::call_site())
+}
+
+#[proc_macro_attribute]
+pub fn plugin(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as PluginArgs);
+    let impl_block = parse_macro_input!(item as ItemImpl);
+    let self_ty = &impl_block.self_ty;
+
+    let name = &args.name;
+    let name_cstr = make_cstr_literal(name);
+    let comment_cstr = make_cstr_literal(args.comment.as_deref().unwrap_or_default());
+    let help_cstr = make_cstr_literal(args.help.as_deref().unwrap_or_default());
+    let hotkey_cstr = make_cstr_literal(args.hotkey.as_deref().unwrap_or_default());
+
+    let base_flags = PLUGIN_MULTI | PLUGIN_MOD;
+    let kind_flag = match args.kind {
+        PluginKind::Default => 0,
+        PluginKind::Resident => PLUGIN_FIX,
+        PluginKind::Oneshot => PLUGIN_UNL,
+    };
+    let computed_flags = base_flags | kind_flag;
+    let version = args.version.unwrap_or(900);
+
+    let expanded = quote! {
+        #impl_block
+
+        extern "C" fn __idalib_plugin_init() -> *mut idalib::ffi::plugin::plugmod_t {
+            let mut idb = match idalib::IDB::current() {
+                Ok(idb) => idb,
+                Err(e) => {
+                    let _ = unsafe {
+                        idalib::ffi::ida::msg(&format!("[{}] plugin initialisation failed: {e}\n", #name))
+                    };
+                    return ::std::ptr::null_mut();
+                }
+            };
+
+            let mut ida = idalib::IDA::new(&idb);
+
+            match <#self_ty as idalib::plugin::IDAPlugin>::init(&mut ida, &mut idb) {
+                Ok(plugin) => {
+                    let wrapper = idalib::plugin::PlugmodWrapper::new(#name, plugin);
+                    let plugmod = Box::new(idalib::ffi::plugin::PlugMod::new(wrapper));
+                    unsafe { idalib::ffi::plugin::idalib_create_plugmod(plugmod) }
+                }
+                Err(e) => {
+                    ida.msg(&format!("[{}] plugin initialisation failed: {e}\n", #name)).ok();
+                    ::std::ptr::null_mut()
+                }
+            }
+        }
+
+        #[unsafe(no_mangle)]
+        pub static mut PLUGIN: idalib::ffi::plugin::plugin_t = idalib::ffi::plugin::plugin_t {
+            version: #version,
+            flags: #computed_flags,
+            init: Some(__idalib_plugin_init),
+            term: None,
+            run: None,
+            comment: #comment_cstr.as_ptr(),
+            help: #help_cstr.as_ptr(),
+            wanted_name: #name_cstr.as_ptr(),
+            wanted_hotkey: #hotkey_cstr.as_ptr(),
+        };
+    };
+
+    expanded.into()
+}

--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idalib-sys"
 authors = ["Sam L. Thomas <st@xv.ax>", "Yegor Vasilenko <yv@yegor.cc>", "Marco Ivaldi <raptor@0xdeadbeef.info>"]
-version = "0.8.1+9.3.260213"
+version = "0.9.0+9.3.260327"
 description = "Idiomatic bindings to IDA SDK"
 repository = "https://github.com/idalib-rs/idalib"
 documentation = "https://idalib.rs/idalib_sys"
@@ -17,10 +17,10 @@ include = [
   "/build.rs",
   "/src",
   "/sdk/src/include",
-  "/sdk/src/lib/x64_linux_gcc_64/*.so",
-  "/sdk/src/lib/x64_mac_clang_64/*.dylib",
-  "/sdk/src/lib/arm64_mac_clang_64/*.dylib",
-  "/sdk/src/lib/x64_win_vc_64/*.lib",
+  "/sdk/src/lib/x64_linux_64/*.so",
+  "/sdk/src/lib/x64_mac_64/*.dylib",
+  "/sdk/src/lib/arm64_mac_64/*.dylib",
+  "/sdk/src/lib/x64_win_64/*.lib",
 ]
 
 [dependencies]
@@ -34,7 +34,7 @@ thiserror = "1"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2"
+objc2 = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }

--- a/idalib-sys/build.rs
+++ b/idalib-sys/build.rs
@@ -26,15 +26,14 @@ fn configure_and_generate(builder: BindgenBuilder, ida: &Path, output: impl AsRe
 }
 
 fn main() {
-    // let sdk_path = PathBuf::from(env::var("IDASDKDIR").expect("IDASDKDIR should be set"));
     let sdk_path =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"))
             .join("sdk/src");
     let ida = sdk_path.join("include");
 
-    cxx_build::CFG.exported_header_dirs.push(&ida);
-
     let ffi_path = Path::new("src");
+
+    cxx_build::CFG.exported_header_dirs.push(&ida);
 
     let mut builder = autocxx_build::Builder::new(ffi_path.join("lib.rs"), [ffi_path, &*ida])
         .extra_clang_args(
@@ -143,7 +142,12 @@ fn main() {
     }
 
     let hexrays = autocxx_bindgen::builder()
-        .header(ffi_path.join("fixups.h").to_str().expect("path is valid string"))
+        .header(
+            ffi_path
+                .join("fixups.h")
+                .to_str()
+                .expect("path is valid string"),
+        )
         .header(ida.join("pro.h").to_str().expect("path is valid string"))
         .header(
             ida.join("hexrays.hpp")
@@ -174,6 +178,18 @@ fn main() {
         .allowlist_item("DECOMP_.*");
 
     configure_and_generate(hexrays, &ida, "hexrays.rs");
+
+    let plugin = autocxx_bindgen::builder()
+        .header(ida.join("pro.h").to_str().expect("path is valid string"))
+        .header(
+            ida.join("loader.hpp")
+                .to_str()
+                .expect("path is valid string"),
+        )
+        .allowlist_item("plugmod_t")
+        .allowlist_item("plugin_t");
+
+    configure_and_generate(plugin, &ida, "plugin.rs");
 
     println!("cargo::metadata=sdk={}", sdk_path.display());
 

--- a/idalib-sys/src/kernwin_extras.h
+++ b/idalib-sys/src/kernwin_extras.h
@@ -172,3 +172,9 @@ rust::String idalib_ea2str(ea_t ea) {
     return rust::String();
   }
 }
+
+void idalib_msg(const char *m) {
+  if (m && *m) {
+    msg("%s", m);
+  }
+}

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -358,7 +358,7 @@ include_cpp! {
     generate!("get_strlist_qty")
 
     // loader
-    generate!("plugin_t")
+    extern_cpp_type!("plugin_t", crate::plugin::plugin_t)
     generate!("find_plugin")
     generate!("run_plugin")
 
@@ -692,6 +692,66 @@ pub mod inf {
     };
 }
 
+pub mod plugin {
+    #![allow(non_camel_case_types)]
+    #![allow(non_upper_case_globals)]
+    #![allow(unused)]
+
+    pub use super::ffi::{find_plugin, run_plugin};
+    pub use super::ffix::{idalib_create_plugmod, idalib_plugin_flags, idalib_plugin_version};
+
+    include!(concat!(env!("OUT_DIR"), "/plugin.rs"));
+
+    unsafe impl cxx::ExternType for plugin_t {
+        type Id = cxx::type_id!("plugin_t");
+        type Kind = cxx::kind::Trivial;
+    }
+
+    unsafe impl cxx::ExternType for plugmod_t {
+        type Id = cxx::type_id!("plugmod_t");
+        type Kind = cxx::kind::Opaque;
+    }
+
+    pub mod flags {
+        pub use crate::ffi::{
+            PLUGIN_DBG, PLUGIN_DRAW, PLUGIN_FIX, PLUGIN_HIDE, PLUGIN_MOD, PLUGIN_MULTI,
+            PLUGIN_PROC, PLUGIN_SCRIPTED, PLUGIN_SEG, PLUGIN_UNL,
+        };
+    }
+
+    pub trait PlugModBridge: Send + Sync + 'static {
+        fn run(&mut self, arg: usize) -> bool;
+        fn term(&mut self);
+    }
+
+    pub struct PlugMod {
+        inner: Box<dyn PlugModBridge>,
+    }
+
+    impl PlugMod {
+        pub fn new<T: PlugModBridge>(inner: T) -> Self {
+            Self {
+                inner: Box::new(inner),
+            }
+        }
+
+        pub fn run(&mut self, arg: usize) -> bool {
+            self.inner.run(arg)
+        }
+
+        pub fn term(&mut self) {
+            self.inner.term();
+        }
+    }
+}
+
+// NOTE: this is required, since we can't do:
+//
+// ```
+// type PlugMod = crate::plugin::PlugMod;
+// ```
+pub(crate) use plugin::PlugMod;
+
 pub mod pod {
     #![allow(non_camel_case_types)]
     #![allow(non_upper_case_globals)]
@@ -719,6 +779,13 @@ mod ffix {
         desc: String,
     }
 
+    extern "Rust" {
+        type PlugMod;
+
+        fn run(self: &mut PlugMod, arg: usize) -> bool;
+        fn term(self: &mut PlugMod);
+    }
+
     unsafe extern "C++" {
         include!("autocxxgen_ffi.h");
         include!("idalib.hpp");
@@ -739,6 +806,7 @@ mod ffix {
         include!("segm_extras.h");
         include!("search_extras.h");
         include!("strings_extras.h");
+        include!("plugin_extras.h");
 
         type c_short = autocxx::c_short;
         type c_int = autocxx::c_int;
@@ -767,7 +835,10 @@ mod ffix {
 
         type cblock_iter;
 
-        type plugin_t = super::ffi::plugin_t;
+        type plugin_t = super::plugin::plugin_t;
+        type plugmod_t = super::plugin::plugmod_t;
+
+        unsafe fn idalib_create_plugmod(pm: Box<PlugMod>) -> *mut plugmod_t;
 
         unsafe fn init_library(argc: c_int, argv: *mut *mut c_char) -> c_int;
 
@@ -1026,6 +1097,8 @@ mod ffix {
 
         unsafe fn idalib_ea2str(ea: c_ulonglong) -> String;
 
+        unsafe fn idalib_msg(msg: *const c_char);
+
         unsafe fn idalib_get_byte(ea: c_ulonglong) -> u8;
         unsafe fn idalib_get_word(ea: c_ulonglong) -> u16;
         unsafe fn idalib_get_dword(ea: c_ulonglong) -> u32;
@@ -1214,18 +1287,6 @@ pub mod strings {
     pub use super::ffix::{idalib_get_strlist_item_addr, idalib_get_strlist_item_length};
 }
 
-pub mod loader {
-    pub use super::ffi::{find_plugin, plugin_t, run_plugin};
-    pub use super::ffix::{idalib_plugin_flags, idalib_plugin_version};
-
-    pub mod flags {
-        pub use super::super::ffi::{
-            PLUGIN_DBG, PLUGIN_DRAW, PLUGIN_FIX, PLUGIN_HIDE, PLUGIN_MOD, PLUGIN_MULTI,
-            PLUGIN_PROC, PLUGIN_SCRIPTED, PLUGIN_SEG, PLUGIN_UNL,
-        };
-    }
-}
-
 pub mod nalt {
     pub use super::ffi::{
         retrieve_input_file_md5, retrieve_input_file_sha256, retrieve_input_file_size,
@@ -1252,6 +1313,13 @@ pub mod ida {
     use super::{IDAError, ea_t, ffi, ffix};
 
     pub use ffi::auto_wait;
+    pub use ffix::idalib_msg;
+
+    pub unsafe fn msg(msg: impl AsRef<str>) -> Result<(), IDAError> {
+        let msg = CString::new(msg.as_ref()).map_err(IDAError::ffi)?;
+        unsafe { ffix::idalib_msg(msg.as_ptr()) };
+        Ok(())
+    }
 
     pub fn is_license_valid() -> bool {
         assert!(

--- a/idalib-sys/src/platform.rs
+++ b/idalib-sys/src/platform.rs
@@ -7,7 +7,7 @@ pub fn is_main_thread() -> bool {
 
 #[cfg(target_os = "macos")]
 pub fn is_main_thread() -> bool {
-    use objc::*;
+    use objc2::*;
 
     #[allow(unexpected_cfgs)]
     unsafe { msg_send![class!(NSThread), isMainThread] }

--- a/idalib-sys/src/plugin_extras.h
+++ b/idalib-sys/src/plugin_extras.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "idp.hpp"
+#include "loader.hpp"
+
+#include "cxxgen1.h"
+
+class rust_plugmod_t : public plugmod_t {
+public:
+    rust::Box<PlugMod> inner;
+
+    rust_plugmod_t(rust::Box<PlugMod> pm) : inner(std::move(pm)) {}
+
+    virtual bool idaapi run(size_t arg) override {
+        return inner->run(arg);
+    }
+
+    virtual ~rust_plugmod_t() {
+        inner->term();
+    }
+};
+
+plugmod_t* idalib_create_plugmod(rust::Box<PlugMod> pm) {
+    return new rust_plugmod_t(std::move(pm));
+}

--- a/idalib/Cargo.toml
+++ b/idalib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "idalib"
 authors = ["Sam L. Thomas <st@xv.ax>", "Yegor Vasilenko <yv@yegor.cc>", "Marco Ivaldi <raptor@0xdeadbeef.info>"]
-version = "0.8.1+9.3.260213"
+version = "0.9.0+9.3.260327"
 description = "Idiomatic bindings to IDA SDK"
 repository = "https://github.com/idalib-rs/idalib"
 documentation = "https://idalib.rs/idalib"
@@ -18,8 +18,8 @@ anyhow = "1"
 autocxx = "0.27"
 bitflags = "2"
 cxx = "1"
-idalib-sys = { version = "0.8", path = "../idalib-sys" }
+idalib-sys = { version = "0.9", path = "../idalib-sys" }
 thiserror = "1"
 
 [build-dependencies]
-idalib-build = { version = "0.8", path = "../idalib-build" }
+idalib-build = { version = "0.9", path = "../idalib-build" }

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
+#[cfg(not(feature = "plugin"))]
 use std::path::{Path, PathBuf};
 
 use crate::ffi::BADADDR;
@@ -11,12 +12,14 @@ use crate::ffi::entry::{get_entry, get_entry_ordinal, get_entry_qty};
 use crate::ffi::func::{
     get_func, get_func_qty, getn_func, idalib_get_func_cmt, idalib_set_func_cmt,
 };
-use crate::ffi::hexrays::{decompile_func, init_hexrays_plugin, term_hexrays_plugin};
-use crate::ffi::ida::{
-    auto_wait, close_database_with, make_signatures, open_database_quiet, set_screen_ea,
-};
+#[cfg(not(feature = "plugin"))]
+use crate::ffi::hexrays::term_hexrays_plugin;
+use crate::ffi::hexrays::{decompile_func, init_hexrays_plugin};
+#[cfg(not(feature = "plugin"))]
+use crate::ffi::ida::{auto_wait, close_database_with, open_database_quiet};
+use crate::ffi::ida::{make_signatures, set_screen_ea};
 use crate::ffi::insn::decode;
-use crate::ffi::loader::find_plugin;
+use crate::ffi::plugin::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
@@ -37,7 +40,9 @@ use crate::xref::{XRef, XRefQuery};
 use crate::{Address, AddressFlags, IDAError, IDARuntimeHandle, prepare_library};
 
 pub struct IDB {
+    #[cfg(not(feature = "plugin"))]
     path: PathBuf,
+    #[cfg(not(feature = "plugin"))]
     save: bool,
     decompiler: bool,
     _guard: IDARuntimeHandle,
@@ -45,6 +50,7 @@ pub struct IDB {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(not(feature = "plugin"))]
 pub struct IDBOpenOptions {
     idb: Option<PathBuf>,
     ftype: Option<String>,
@@ -53,6 +59,7 @@ pub struct IDBOpenOptions {
     auto_analyse: bool,
 }
 
+#[cfg(not(feature = "plugin"))]
 impl Default for IDBOpenOptions {
     fn default() -> Self {
         Self {
@@ -64,6 +71,7 @@ impl Default for IDBOpenOptions {
     }
 }
 
+#[cfg(not(feature = "plugin"))]
 impl IDBOpenOptions {
     pub fn new() -> Self {
         Self::default()
@@ -106,10 +114,12 @@ impl IDBOpenOptions {
 }
 
 impl IDB {
+    #[cfg(not(feature = "plugin"))]
     pub fn open(path: impl AsRef<Path>) -> Result<Self, IDAError> {
         Self::open_with(path, true, false)
     }
 
+    #[cfg(not(feature = "plugin"))]
     pub fn open_with(
         path: impl AsRef<Path>,
         auto_analyse: bool,
@@ -118,6 +128,7 @@ impl IDB {
         Self::open_full_with(path, auto_analyse, save, &[] as &[&str])
     }
 
+    #[cfg(not(feature = "plugin"))]
     fn open_full_with(
         path: impl AsRef<Path>,
         auto_analyse: bool,
@@ -144,14 +155,28 @@ impl IDB {
         })
     }
 
+    #[cfg(feature = "plugin")]
+    pub fn current() -> Result<Self, IDAError> {
+        let _guard = prepare_library();
+
+        Ok(Self {
+            decompiler: unsafe { init_hexrays_plugin(0.into()) },
+            _guard,
+            _marker: PhantomData,
+        })
+    }
+
+    #[cfg(not(feature = "plugin"))]
     pub fn path(&self) -> &Path {
         &self.path
     }
 
+    #[cfg(not(feature = "plugin"))]
     pub fn save_on_close(&mut self, status: bool) {
         self.save = status;
     }
 
+    #[cfg(not(feature = "plugin"))]
     pub fn auto_wait(&mut self) -> bool {
         unsafe { auto_wait() }
     }
@@ -572,7 +597,7 @@ impl IDB {
                 name.as_ref()
             )))
         } else {
-            Ok(Plugin::from_ptr(ptr))
+            Ok(Plugin::from_ptr(ptr as *const _))
         }
     }
 
@@ -581,6 +606,7 @@ impl IDB {
     }
 }
 
+#[cfg(not(feature = "plugin"))]
 impl Drop for IDB {
     fn drop(&mut self) {
         if self.decompiler {

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -94,8 +94,15 @@ pub mod xref;
 pub use idalib_sys as ffi;
 
 pub use ffi::IDAError;
-pub use idb::{IDB, IDBOpenOptions};
+pub use idb::IDB;
+#[cfg(not(feature = "plugin"))]
+pub use idb::IDBOpenOptions;
 pub use license::{LicenseId, is_valid_license, license_id};
+#[cfg(feature = "plugin")]
+pub use plugin::{IDAPlugin, PluginFlags};
+
+#[cfg(feature = "plugin")]
+pub use idalib_macros::plugin;
 
 pub type Address = u64;
 pub struct AddressFlags<'a> {
@@ -117,6 +124,20 @@ impl<'a> AddressFlags<'a> {
 
     pub fn is_data(&self) -> bool {
         unsafe { ffi::bytes::is_data(self.flags) }
+    }
+}
+
+pub struct IDA;
+
+impl IDA {
+    pub fn new(_: &IDB) -> Self {
+        // NOTE: we take the IDB as an argument to ensure that the caller has access to it,
+        // therefore ensuring the library is correctly initialised.
+        Self
+    }
+
+    pub fn msg(&self, message: impl AsRef<str>) -> Result<(), IDAError> {
+        unsafe { ffi::ida::msg(message) }
     }
 }
 
@@ -143,13 +164,14 @@ impl IDAVersion {
 
 static INIT: OnceLock<Mutex<()>> = OnceLock::new();
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", feature = "plugin")))]
 unsafe extern "C" {
     static mut batch: std::ffi::c_char;
 }
 
 pub(crate) type IDARuntimeHandle = MutexGuard<'static, ()>;
 
+#[cfg(not(feature = "plugin"))]
 pub fn force_batch_mode() {
     #[cfg(not(target_os = "windows"))]
     unsafe {
@@ -157,6 +179,12 @@ pub fn force_batch_mode() {
     }
 }
 
+#[cfg(feature = "plugin")]
+pub fn init_library() -> &'static Mutex<()> {
+    INIT.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(not(feature = "plugin"))]
 pub fn init_library() -> &'static Mutex<()> {
     INIT.get_or_init(|| {
         force_batch_mode();
@@ -170,6 +198,7 @@ pub(crate) fn prepare_library() -> IDARuntimeHandle {
     mutex.lock().unwrap()
 }
 
+#[cfg(not(feature = "plugin"))]
 pub fn enable_console_messages(enabled: bool) {
     init_library();
     ffi::ida::enable_console_messages(enabled);

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -10,10 +10,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! idalib = "0.8"
+//! idalib = "0.9"
 //!
 //! [build-dependencies]
-//! idalib-build = "0.8"
+//! idalib-build = "0.9"
 //! ```
 //!
 //! Here is a basic example of a `build.rs` file:

--- a/idalib/src/plugin/mod.rs
+++ b/idalib/src/plugin/mod.rs
@@ -2,10 +2,16 @@ use std::marker::PhantomData;
 
 use bitflags::bitflags;
 
-use crate::ffi::loader::*;
+use crate::ffi::plugin::*;
 use crate::idb::IDB;
 
 pub use crate::ffi::processor::ids as id;
+
+#[cfg(feature = "plugin")]
+mod plugmod;
+#[cfg(feature = "plugin")]
+pub use plugmod::*;
+
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -37,7 +43,7 @@ impl<'a> Plugin<'a> {
     }
 
     pub fn run(&self, arg: usize) -> bool {
-        unsafe { run_plugin(&*self.ptr, arg) }
+        unsafe { run_plugin(self.ptr, arg) }
     }
 
     pub fn version(&self) -> u64 {

--- a/idalib/src/plugin/plugmod.rs
+++ b/idalib/src/plugin/plugmod.rs
@@ -1,0 +1,70 @@
+use crate::ffi::ida::msg;
+use crate::ffi::plugin::PlugModBridge;
+use crate::idb::IDB;
+use crate::{IDA, IDAError};
+
+pub trait IDAPlugin: Sized + Send + Sync + 'static {
+    fn init(ida: &mut IDA, idb: &mut IDB) -> Result<Self, IDAError>;
+
+    fn run(&mut self, ida: &mut IDA, idb: &mut IDB, arg: usize) -> Result<(), IDAError>;
+
+    fn term(&mut self, _ida: &mut IDA, _idb: &mut IDB) -> Result<(), IDAError> {
+        Ok(())
+    }
+}
+
+trait IDAPluginErased: Send + Sync {
+    fn run(&mut self, ida: &mut IDA, idb: &mut IDB, arg: usize) -> Result<(), IDAError>;
+    fn term(&mut self, ida: &mut IDA, idb: &mut IDB) -> Result<(), IDAError>;
+}
+
+impl<P: IDAPlugin> IDAPluginErased for P {
+    fn run(&mut self, ida: &mut IDA, idb: &mut IDB, arg: usize) -> Result<(), IDAError> {
+        IDAPlugin::run(self, ida, idb, arg)
+    }
+
+    fn term(&mut self, ida: &mut IDA, idb: &mut IDB) -> Result<(), IDAError> {
+        IDAPlugin::term(self, ida, idb)
+    }
+}
+
+#[doc(hidden)]
+pub struct PlugmodWrapper {
+    name: &'static str,
+    plugin: Box<dyn IDAPluginErased>,
+}
+
+impl PlugmodWrapper {
+    pub fn new(name: &'static str, plugin: impl IDAPlugin) -> Self {
+        Self {
+            name,
+            plugin: Box::new(plugin),
+        }
+    }
+}
+
+impl PlugModBridge for PlugmodWrapper {
+    fn run(&mut self, arg: usize) -> bool {
+        let result = IDB::current().and_then(|mut idb| {
+            let mut ida = IDA::new(&idb);
+            self.plugin.run(&mut ida, &mut idb, arg)
+        });
+        match result {
+            Ok(()) => true,
+            Err(e) => {
+                let _ = unsafe { msg(&format!("[{}] `run` failed: {e}\n", self.name)) };
+                false
+            }
+        }
+    }
+
+    fn term(&mut self) {
+        let result = IDB::current().and_then(|mut idb| {
+            let mut ida = IDA::new(&idb);
+            self.plugin.term(&mut ida, &mut idb)
+        });
+        if let Err(e) = result {
+            let _ = unsafe { msg(&format!("[{}] `term` failed: {e}\n", self.name)) };
+        }
+    }
+}


### PR DESCRIPTION
This PR provides support for v9.3 SP1. Notably, the stub libraries have changed path, removing compiler names from their directory names, which is a breaking change and not backwards compatible with previous SDK versions (see: https://github.com/HexRaysSA/ida-sdk/commit/acacbbcc8fa349d919cc185d88b1ab3710ca252d).