### PR TITLE
Switch from `objc` to `objc2` that is more actively maintained

### DIFF
--- a/idalib-sys/Cargo.toml
+++ b/idalib-sys/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1"
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2"
+objc2 = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_System_Threading"] }

--- a/idalib-sys/src/platform.rs
+++ b/idalib-sys/src/platform.rs
@@ -7,9 +7,8 @@ pub fn is_main_thread() -> bool {
 
 #[cfg(target_os = "macos")]
 pub fn is_main_thread() -> bool {
-    use objc::*;
+    use objc2::*;
 
-    #[allow(unexpected_cfgs)]
     unsafe { msg_send![class!(NSThread), isMainThread] }
 }
 


### PR DESCRIPTION
I tracked a warning that popped out while compiling `idalib-sys` on macOS to the [`objc`](https://crates.io/crates/objc) dependency, which seems unmaintained (it was updated 6 years ago). Therefore, I thought a switch to [`objc2`](https://crates.io/crates/objc2) might be a good idea. 