### PR TITLE
Add typeinf functionality to dump local types

### DIFF
--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -739,6 +739,7 @@ mod ffix {
         include!("segm_extras.h");
         include!("search_extras.h");
         include!("strings_extras.h");
+        include!("typeinf_extras.h");
 
         type c_short = autocxx::c_short;
         type c_int = autocxx::c_int;
@@ -1042,6 +1043,8 @@ mod ffix {
             minor: *mut c_int,
             build: *mut c_int,
         ) -> bool;
+
+        unsafe fn idalib_print_decls(flags: u32) -> Result<String>;
     }
 }
 
@@ -1212,6 +1215,10 @@ pub mod search {
 pub mod strings {
     pub use super::ffi::{build_strlist, clear_strlist, get_strlist_qty};
     pub use super::ffix::{idalib_get_strlist_item_addr, idalib_get_strlist_item_length};
+}
+
+pub mod typeinf {
+    pub use super::ffix::idalib_print_decls;
 }
 
 pub mod loader {

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -357,6 +357,13 @@ include_cpp! {
     generate!("clear_strlist")
     generate!("get_strlist_qty")
 
+    // typeinf
+    generate!("PDF_INCL_DEPS")
+    generate!("PDF_DEF_FWD")
+    generate!("PDF_DEF_BASE")
+    generate!("PDF_HEADER_CMT")
+    generate!("PDF_NO_ANON_NAME")
+
     // loader
     generate!("plugin_t")
     generate!("find_plugin")
@@ -1044,7 +1051,7 @@ mod ffix {
             build: *mut c_int,
         ) -> bool;
 
-        unsafe fn idalib_print_decls(flags: u32) -> Result<String>;
+        unsafe fn idalib_format_decls(flags: u32) -> Result<String>;
     }
 }
 
@@ -1218,7 +1225,10 @@ pub mod strings {
 }
 
 pub mod typeinf {
-    pub use super::ffix::idalib_print_decls;
+    pub use super::ffi::{
+        PDF_DEF_BASE, PDF_DEF_FWD, PDF_HEADER_CMT, PDF_INCL_DEPS, PDF_NO_ANON_NAME,
+    };
+    pub use super::ffix::idalib_format_decls;
 }
 
 pub mod loader {

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "typeinf.hpp"
+#include "pro.h"
+#include "cxx.h"
+
+#include <sstream>
+
+struct idalib_string_sink_t : text_sink_t {
+  std::ostringstream buf;
+  int idaapi print(const char *str) override {
+    buf << str;
+    return 0;
+  }
+};
+
+// Calls `print_decls()` with the current IDB's type library (`get_idati()`).
+// Returns the declarations as a string. Throws if `print_decls()` signals a
+// hard failure (return value == 0).
+rust::String idalib_print_decls(uint32 flags) {
+  idalib_string_sink_t sink;
+  int result = print_decls(sink, get_idati(), nullptr, flags);
+  if (result == 0) {
+    throw std::runtime_error("print_decls failed");
+  }
+  return rust::String(sink.buf.str());
+}

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -17,7 +17,7 @@ struct idalib_string_sink_t : text_sink_t {
 // Calls `print_decls()` with the current IDB's type library (`get_idati()`).
 // Returns the declarations as a string. Throws if `print_decls()` signals a
 // hard failure (return value == 0).
-rust::String idalib_print_decls(uint32 flags) {
+rust::String idalib_format_decls(uint32 flags) {
   idalib_string_sink_t sink;
   int result = print_decls(sink, get_idati(), nullptr, flags);
   if (result == 0) {

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -1,0 +1,11 @@
+use idalib::idb::IDB;
+use idalib::typeinf::PrintDeclsFlags;
+
+fn main() -> anyhow::Result<()> {
+    let idb = IDB::open("./tests/ls")?;
+
+    let decls = idb.print_decls(PrintDeclsFlags::INCL_DEPS | PrintDeclsFlags::DEF_FWD)?;
+    println!("{decls}");
+
+    Ok(())
+}

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -1,10 +1,10 @@
 use idalib::idb::IDB;
-use idalib::typeinf::PrintDeclsFlags;
+use idalib::typeinf::FormatDeclsOptions;
 
 fn main() -> anyhow::Result<()> {
     let idb = IDB::open("./tests/ls")?;
 
-    let decls = idb.print_decls(PrintDeclsFlags::INCL_DEPS | PrintDeclsFlags::DEF_FWD)?;
+    let decls = idb.format_decls(FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD)?;
     println!("{decls}");
 
     Ok(())

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -20,6 +20,7 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
+use crate::ffi::typeinf::idalib_print_decls;
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
 
@@ -33,6 +34,7 @@ use crate::plugin::Plugin;
 use crate::processor::Processor;
 use crate::segment::{Segment, SegmentId};
 use crate::strings::StringList;
+use crate::typeinf::PrintDeclsFlags;
 use crate::xref::{XRef, XRefQuery};
 use crate::{Address, AddressFlags, IDAError, IDARuntimeHandle, prepare_library};
 
@@ -162,6 +164,11 @@ impl IDB {
 
     pub fn make_signatures(&mut self, only_pat: bool) -> Result<(), IDAError> {
         make_signatures(only_pat)
+    }
+
+    pub fn print_decls(&self, flags: PrintDeclsFlags) -> Result<String, IDAError> {
+        unsafe { idalib_print_decls(flags.bits()) }
+            .map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -20,7 +20,7 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
-use crate::ffi::typeinf::idalib_print_decls;
+use crate::ffi::typeinf::idalib_format_decls;
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
 
@@ -34,7 +34,7 @@ use crate::plugin::Plugin;
 use crate::processor::Processor;
 use crate::segment::{Segment, SegmentId};
 use crate::strings::StringList;
-use crate::typeinf::PrintDeclsFlags;
+use crate::typeinf::FormatDeclsOptions;
 use crate::xref::{XRef, XRefQuery};
 use crate::{Address, AddressFlags, IDAError, IDARuntimeHandle, prepare_library};
 
@@ -166,9 +166,8 @@ impl IDB {
         make_signatures(only_pat)
     }
 
-    pub fn print_decls(&self, flags: PrintDeclsFlags) -> Result<String, IDAError> {
-        unsafe { idalib_print_decls(flags.bits()) }
-            .map_err(IDAError::ffi)
+    pub fn format_decls(&self, options: FormatDeclsOptions) -> Result<String, IDAError> {
+        unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -89,6 +89,7 @@ pub mod plugin;
 pub mod processor;
 pub mod segment;
 pub mod strings;
+pub mod typeinf;
 pub mod xref;
 
 pub use idalib_sys as ffi;

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -1,0 +1,22 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Flags controlling how type declarations are printed by [`IDB::print_decls`].
+    ///
+    /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
+    ///
+    /// [`IDB::print_decls`]: crate::idb::IDB::print_decls
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct PrintDeclsFlags: u32 {
+        /// Include all type dependencies.
+        const INCL_DEPS    = 0x01;
+        /// Allow forward declarations.
+        const DEF_FWD      = 0x02;
+        /// Include base types: `__int8`, `__int16`, etc.
+        const DEF_BASE     = 0x04;
+        /// Prepend output with a descriptive comment.
+        const HEADER_CMT   = 0x08;
+        /// Ignore types with anonymous names.
+        const NO_ANON_NAME = 0x10;
+    }
+}

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -1,22 +1,24 @@
 use bitflags::bitflags;
 
+use crate::ffi::typeinf::*;
+
 bitflags! {
-    /// Flags controlling how type declarations are printed by [`IDB::print_decls`].
+    /// Flags controlling how type declarations are printed by [`IDB::format_decls`].
     ///
     /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
     ///
-    /// [`IDB::print_decls`]: crate::idb::IDB::print_decls
+    /// [`IDB::format_decls`]: crate::idb::IDB::format_decls
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct PrintDeclsFlags: u32 {
+    pub struct FormatDeclsOptions: u32 {
         /// Include all type dependencies.
-        const INCL_DEPS    = 0x01;
+        const INCL_DEPS = PDF_INCL_DEPS as _;
         /// Allow forward declarations.
-        const DEF_FWD      = 0x02;
+        const DEF_FWD = PDF_DEF_FWD as _;
         /// Include base types: `__int8`, `__int16`, etc.
-        const DEF_BASE     = 0x04;
+        const DEF_BASE = PDF_DEF_BASE as _;
         /// Prepend output with a descriptive comment.
-        const HEADER_CMT   = 0x08;
+        const HEADER_CMT = PDF_HEADER_CMT as _;
         /// Ignore types with anonymous names.
-        const NO_ANON_NAME = 0x10;
+        const NO_ANON_NAME = PDF_NO_ANON_NAME as _;
     }
 }


### PR DESCRIPTION
In response to https://github.com/0xdea/haruspex/issues/3, I added the ability to programmatically dump local types. Please let me know if it can be merged as is or if it needs additional work. Cheers!