### PR TITLE
Add global and per-function type extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /**/Cargo.lock
 /beta3
 /beta4
+.idea
+.DS_Store

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -1053,10 +1053,7 @@ mod ffix {
 
         unsafe fn idalib_format_decls(flags: u32) -> Result<String>;
 
-        unsafe fn idalib_format_func_type_info(
-            cfunc: *mut cfunc_t,
-            flags: u32,
-        ) -> Result<String>;
+        unsafe fn idalib_format_func_decls(cfunc: *mut cfunc_t, flags: u32) -> Result<String>;
     }
 }
 
@@ -1233,7 +1230,7 @@ pub mod typeinf {
     pub use super::ffi::{
         PDF_DEF_BASE, PDF_DEF_FWD, PDF_HEADER_CMT, PDF_INCL_DEPS, PDF_NO_ANON_NAME,
     };
-    pub use super::ffix::{idalib_format_decls, idalib_format_func_type_info};
+    pub use super::ffix::{idalib_format_decls, idalib_format_func_decls};
 }
 
 pub mod loader {

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -739,6 +739,7 @@ mod ffix {
         include!("segm_extras.h");
         include!("search_extras.h");
         include!("strings_extras.h");
+        include!("typeinf_extras.h");
 
         type c_short = autocxx::c_short;
         type c_int = autocxx::c_int;
@@ -1042,6 +1043,8 @@ mod ffix {
             minor: *mut c_int,
             build: *mut c_int,
         ) -> bool;
+
+        unsafe fn idalib_print_decls(flags: u32) -> Result<String>;
     }
 }
 
@@ -1212,6 +1215,10 @@ pub mod search {
 pub mod strings {
     pub use super::ffi::{build_strlist, clear_strlist, get_strlist_qty};
     pub use super::ffix::{idalib_get_strlist_item_addr, idalib_get_strlist_item_length};
+}
+
+pub mod typeinf {
+    pub use super::ffix::idalib_print_decls;
 }
 
 pub mod loader {

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -1052,6 +1052,12 @@ mod ffix {
         ) -> bool;
 
         unsafe fn idalib_format_decls(flags: u32) -> Result<String>;
+
+        unsafe fn idalib_format_func_type_info(
+            ea: c_ulonglong,
+            cfunc: *mut cfunc_t,
+            flags: u32,
+        ) -> Result<String>;
     }
 }
 
@@ -1228,7 +1234,7 @@ pub mod typeinf {
     pub use super::ffi::{
         PDF_DEF_BASE, PDF_DEF_FWD, PDF_HEADER_CMT, PDF_INCL_DEPS, PDF_NO_ANON_NAME,
     };
-    pub use super::ffix::idalib_format_decls;
+    pub use super::ffix::{idalib_format_decls, idalib_format_func_type_info};
 }
 
 pub mod loader {

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -1054,7 +1054,6 @@ mod ffix {
         unsafe fn idalib_format_decls(flags: u32) -> Result<String>;
 
         unsafe fn idalib_format_func_type_info(
-            ea: c_ulonglong,
             cfunc: *mut cfunc_t,
             flags: u32,
         ) -> Result<String>;

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -1053,7 +1053,7 @@ mod ffix {
 
         unsafe fn idalib_format_decls(flags: u32) -> Result<String>;
 
-        unsafe fn idalib_format_func_decls(cfunc: *mut cfunc_t, flags: u32) -> Result<String>;
+        unsafe fn idalib_format_cfunc_decls(cfunc: *mut cfunc_t, flags: u32) -> Result<String>;
     }
 }
 
@@ -1080,7 +1080,6 @@ pub mod insn {
 
     use super::ea_t;
     use super::ffi::decode_insn;
-
     pub use super::pod::insn_t;
 
     pub fn decode(ea: ea_t) -> Option<insn_t> {
@@ -1159,7 +1158,6 @@ pub mod processor {
     pub use super::ffix::{
         idalib_is_thumb_at, idalib_ph_id, idalib_ph_long_name, idalib_ph_short_name,
     };
-
     pub use super::idp as ids;
 }
 
@@ -1172,7 +1170,6 @@ pub mod segment {
         saRel512Bytes, saRel1024Bytes, saRel2048Bytes, saRelByte, saRelDble, saRelPage, saRelPara,
         saRelQword, saRelWord, segment_t,
     };
-
     pub use super::ffix::{
         idalib_segm_align, idalib_segm_bitness, idalib_segm_bytes, idalib_segm_name,
         idalib_segm_perm, idalib_segm_type,
@@ -1230,7 +1227,7 @@ pub mod typeinf {
     pub use super::ffi::{
         PDF_DEF_BASE, PDF_DEF_FWD, PDF_HEADER_CMT, PDF_INCL_DEPS, PDF_NO_ANON_NAME,
     };
-    pub use super::ffix::{idalib_format_decls, idalib_format_func_decls};
+    pub use super::ffix::{idalib_format_cfunc_decls, idalib_format_decls};
 }
 
 pub mod loader {
@@ -1260,17 +1257,15 @@ pub mod name {
 }
 
 pub mod ida {
-    use std::env;
     use std::ffi::CString;
     use std::path::Path;
-    use std::ptr;
+    use std::{env, ptr};
 
     use autocxx::prelude::*;
+    pub use ffi::auto_wait;
 
     use super::platform::is_main_thread;
     use super::{IDAError, ea_t, ffi, ffix};
-
-    pub use ffi::auto_wait;
 
     pub fn is_license_valid() -> bool {
         assert!(

--- a/idalib-sys/src/lib.rs
+++ b/idalib-sys/src/lib.rs
@@ -357,6 +357,13 @@ include_cpp! {
     generate!("clear_strlist")
     generate!("get_strlist_qty")
 
+    // typeinf
+    generate!("PDF_INCL_DEPS")
+    generate!("PDF_DEF_FWD")
+    generate!("PDF_DEF_BASE")
+    generate!("PDF_HEADER_CMT")
+    generate!("PDF_NO_ANON_NAME")
+
     // loader
     generate!("plugin_t")
     generate!("find_plugin")
@@ -1044,7 +1051,7 @@ mod ffix {
             build: *mut c_int,
         ) -> bool;
 
-        unsafe fn idalib_print_decls(flags: u32) -> Result<String>;
+        unsafe fn idalib_format_decls(flags: u32) -> Result<String>;
     }
 }
 
@@ -1218,7 +1225,10 @@ pub mod strings {
 }
 
 pub mod typeinf {
-    pub use super::ffix::idalib_print_decls;
+    pub use super::ffi::{
+        PDF_DEF_BASE, PDF_DEF_FWD, PDF_HEADER_CMT, PDF_INCL_DEPS, PDF_NO_ANON_NAME,
+    };
+    pub use super::ffix::idalib_format_decls;
 }
 
 pub mod loader {

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -67,7 +67,7 @@ rust::String idalib_format_decls(uint32 flags) {
 // Collect named-type ordinals used by a decompiled function's local variables
 // (arguments, return value, locals) and emit just those types plus their
 // transitive dependencies (via PDF_INCL_DEPS).
-rust::String idalib_format_func_type_info(cfunc_t *cfunc, uint32 flags) {
+rust::String idalib_format_func_decls(cfunc_t *cfunc, uint32 flags) {
   std::set<uint32> seen;
 
   lvars_t *lvars = cfunc->get_lvars();

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -16,6 +16,19 @@ struct idalib_string_sink_t : text_sink_t {
   }
 };
 
+// Call `print_decls()` with the current IDB's type library (`get_idati()`).
+// Return the declarations as a string.
+//
+// Throw if `print_decls()` signals a hard failure (return value == 0).
+rust::String idalib_format_decls(uint32 flags) {
+  idalib_string_sink_t sink;
+  int result = print_decls(sink, get_idati(), nullptr, flags);
+  if (result == 0) {
+    throw std::runtime_error("print_decls failed");
+  }
+  return rust::String(sink.buf.str());
+}
+
 // Recursively collect named-type ordinals reachable from `tif` into `seen`.
 // Stops at typeref boundaries: `print_decls(PDF_INCL_DEPS)` handles the
 // transitive closure from those seeds, so we only need the direct references.
@@ -50,19 +63,6 @@ static void collect_tinfo_ordinals(const tinfo_t &tif, std::set<uint32> &seen) {
         collect_tinfo_ordinals(arg.type, seen);
     }
   }
-}
-
-// Call `print_decls()` with the current IDB's type library (`get_idati()`).
-// Return the declarations as a string.
-//
-// Throw if `print_decls()` signals a hard failure (return value == 0).
-rust::String idalib_format_decls(uint32 flags) {
-  idalib_string_sink_t sink;
-  int result = print_decls(sink, get_idati(), nullptr, flags);
-  if (result == 0) {
-    throw std::runtime_error("print_decls failed");
-  }
-  return rust::String(sink.buf.str());
 }
 
 // Collect named-type ordinals used by a decompiled function's local variables

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "typeinf.hpp"
+#include "pro.h"
+#include "cxx.h"
+
+#include <sstream>
+
+struct idalib_string_sink_t : text_sink_t {
+  std::ostringstream buf;
+  int idaapi print(const char *str) override {
+    buf << str;
+    return 0;
+  }
+};
+
+// Calls `print_decls()` with the current IDB's type library (`get_idati()`).
+// Returns the declarations as a string. Throws if `print_decls()` signals a
+// hard failure (return value == 0).
+rust::String idalib_print_decls(uint32 flags) {
+  idalib_string_sink_t sink;
+  int result = print_decls(sink, get_idati(), nullptr, flags);
+  if (result == 0) {
+    throw std::runtime_error("print_decls failed");
+  }
+  return rust::String(sink.buf.str());
+}

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "hexrays.hpp"
-#include "nalt.hpp"
 #include "typeinf.hpp"
 #include "pro.h"
 #include "cxx.h"
@@ -65,31 +64,26 @@ rust::String idalib_format_decls(uint32 flags) {
   return rust::String(sink.buf.str());
 }
 
-// Collect type ordinals for a function at `ea` from its prototype and
-// (if non-null) its decompiled local variables, then emit just those types
-// (and their transitive dependencies, via PDF_INCL_DEPS).
-rust::String idalib_format_func_type_info(
-    unsigned long long ea, cfunc_t *cfunc, uint32 flags) {
+// Collect named-type ordinals used by a decompiled function's local variables
+// (arguments, return value, locals) and emit just those types plus their
+// transitive dependencies (via PDF_INCL_DEPS).
+rust::String idalib_format_func_type_info(cfunc_t *cfunc, uint32 flags) {
   std::set<uint32> seen;
 
-  tinfo_t tif;
-  if (get_tinfo(&tif, (ea_t)ea))
-    collect_tinfo_ordinals(tif, seen);
-
-  if (cfunc != nullptr) {
-    lvars_t *lvars = cfunc->get_lvars();
-    if (lvars != nullptr) {
-      for (const auto &lv : *lvars)
-        collect_tinfo_ordinals(lv.tif, seen);
-    }
+  lvars_t *lvars = cfunc->get_lvars();
+  if (lvars != nullptr) {
+    for (const auto &lv : *lvars)
+      collect_tinfo_ordinals(lv.tif, seen);
   }
+
+  if (seen.empty())
+    return rust::String();
 
   ordvec_t ordinals;
   for (uint32 ord : seen) ordinals.push_back(ord);
 
   idalib_string_sink_t sink;
-  const ordvec_t *ordp = ordinals.empty() ? nullptr : &ordinals;
-  int result = print_decls(sink, get_idati(), ordp, flags);
+  int result = print_decls(sink, get_idati(), &ordinals, flags);
   if (result == 0) {
     throw std::runtime_error("print_decls failed");
   }

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -17,7 +17,7 @@ struct idalib_string_sink_t : text_sink_t {
 // Calls `print_decls()` with the current IDB's type library (`get_idati()`).
 // Returns the declarations as a string. Throws if `print_decls()` signals a
 // hard failure (return value == 0).
-rust::String idalib_print_decls(uint32 flags) {
+rust::String idalib_format_decls(uint32 flags) {
   idalib_string_sink_t sink;
   int result = print_decls(sink, get_idati(), nullptr, flags);
   if (result == 0) {

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -67,7 +67,7 @@ rust::String idalib_format_decls(uint32 flags) {
 // Collect named-type ordinals used by a decompiled function's local variables
 // (arguments, return value, locals) and emit just those types plus their
 // transitive dependencies (via PDF_INCL_DEPS).
-rust::String idalib_format_func_decls(cfunc_t *cfunc, uint32 flags) {
+rust::String idalib_format_cfunc_decls(cfunc_t *cfunc, uint32 flags) {
   std::set<uint32> seen;
 
   lvars_t *lvars = cfunc->get_lvars();

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -73,7 +73,7 @@ static void collect_tinfo_ordinals(const tinfo_t &tif, std::set<uint32> &seen) {
 rust::String idalib_format_cfunc_decls(cfunc_t *cfunc, uint32 flags) {
   std::set<uint32> seen;
 
-  // `lvars_t` should covers everything: arguments (`CVAR_ARG`), the return value
+  // `lvars_t` should cover everything: arguments (`CVAR_ARG`), the return value
   // (`CVAR_RESULT`), and all locals.
   lvars_t *lvars = cfunc->get_lvars();
   if (lvars != nullptr) {

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -52,9 +52,10 @@ static void collect_tinfo_ordinals(const tinfo_t &tif, std::set<uint32> &seen) {
   }
 }
 
-// Calls `print_decls()` with the current IDB's type library (`get_idati()`).
-// Returns the declarations as a string. Throws if `print_decls()` signals a
-// hard failure (return value == 0).
+// Call `print_decls()` with the current IDB's type library (`get_idati()`).
+// Return the declarations as a string.
+//
+// Throw if `print_decls()` signals a hard failure (return value == 0).
 rust::String idalib_format_decls(uint32 flags) {
   idalib_string_sink_t sink;
   int result = print_decls(sink, get_idati(), nullptr, flags);
@@ -67,6 +68,8 @@ rust::String idalib_format_decls(uint32 flags) {
 // Collect named-type ordinals used by a decompiled function's local variables
 // (arguments, return value, locals) and emit just those types plus their
 // transitive dependencies (via `PDF_INCL_DEPS`).
+//
+// Throw if `print_decls()` signals a hard failure (return value == 0).
 rust::String idalib_format_cfunc_decls(cfunc_t *cfunc, uint32 flags) {
   std::set<uint32> seen;
 

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -17,7 +17,7 @@ struct idalib_string_sink_t : text_sink_t {
 };
 
 // Recursively collect named-type ordinals reachable from `tif` into `seen`.
-// Stops at typeref boundaries: print_decls(PDF_INCL_DEPS) handles the
+// Stops at typeref boundaries: `print_decls(PDF_INCL_DEPS)` handles the
 // transitive closure from those seeds, so we only need the direct references.
 static void collect_tinfo_ordinals(const tinfo_t &tif, std::set<uint32> &seen) {
   if (!tif.is_correct()) return;
@@ -66,10 +66,12 @@ rust::String idalib_format_decls(uint32 flags) {
 
 // Collect named-type ordinals used by a decompiled function's local variables
 // (arguments, return value, locals) and emit just those types plus their
-// transitive dependencies (via PDF_INCL_DEPS).
+// transitive dependencies (via `PDF_INCL_DEPS`).
 rust::String idalib_format_cfunc_decls(cfunc_t *cfunc, uint32 flags) {
   std::set<uint32> seen;
 
+  // `lvars_t` should covers everything: arguments (`CVAR_ARG`), the return value
+  // (`CVAR_RESULT`), and all locals.
   lvars_t *lvars = cfunc->get_lvars();
   if (lvars != nullptr) {
     for (const auto &lv : *lvars)

--- a/idalib-sys/src/typeinf_extras.h
+++ b/idalib-sys/src/typeinf_extras.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "hexrays.hpp"
+#include "nalt.hpp"
 #include "typeinf.hpp"
 #include "pro.h"
 #include "cxx.h"
 
+#include <set>
 #include <sstream>
 
 struct idalib_string_sink_t : text_sink_t {
@@ -14,12 +17,79 @@ struct idalib_string_sink_t : text_sink_t {
   }
 };
 
+// Recursively collect named-type ordinals reachable from `tif` into `seen`.
+// Stops at typeref boundaries: print_decls(PDF_INCL_DEPS) handles the
+// transitive closure from those seeds, so we only need the direct references.
+static void collect_tinfo_ordinals(const tinfo_t &tif, std::set<uint32> &seen) {
+  if (!tif.is_correct()) return;
+
+  if (tif.is_typeref()) {
+    uint32 ord = tif.get_ordinal();
+    if (ord != 0) seen.insert(ord);
+    return;
+  }
+
+  if (tif.is_ptr()) {
+    ptr_type_data_t pi;
+    if (tif.get_ptr_details(&pi))
+      collect_tinfo_ordinals(pi.obj_type, seen);
+    return;
+  }
+
+  if (tif.is_array()) {
+    array_type_data_t ai;
+    if (tif.get_array_details(&ai))
+      collect_tinfo_ordinals(ai.elem_type, seen);
+    return;
+  }
+
+  if (tif.is_func()) {
+    func_type_data_t fi;
+    if (tif.get_func_details(&fi)) {
+      collect_tinfo_ordinals(fi.rettype, seen);
+      for (const auto &arg : fi)
+        collect_tinfo_ordinals(arg.type, seen);
+    }
+  }
+}
+
 // Calls `print_decls()` with the current IDB's type library (`get_idati()`).
 // Returns the declarations as a string. Throws if `print_decls()` signals a
 // hard failure (return value == 0).
 rust::String idalib_format_decls(uint32 flags) {
   idalib_string_sink_t sink;
   int result = print_decls(sink, get_idati(), nullptr, flags);
+  if (result == 0) {
+    throw std::runtime_error("print_decls failed");
+  }
+  return rust::String(sink.buf.str());
+}
+
+// Collect type ordinals for a function at `ea` from its prototype and
+// (if non-null) its decompiled local variables, then emit just those types
+// (and their transitive dependencies, via PDF_INCL_DEPS).
+rust::String idalib_format_func_type_info(
+    unsigned long long ea, cfunc_t *cfunc, uint32 flags) {
+  std::set<uint32> seen;
+
+  tinfo_t tif;
+  if (get_tinfo(&tif, (ea_t)ea))
+    collect_tinfo_ordinals(tif, seen);
+
+  if (cfunc != nullptr) {
+    lvars_t *lvars = cfunc->get_lvars();
+    if (lvars != nullptr) {
+      for (const auto &lv : *lvars)
+        collect_tinfo_ordinals(lv.tif, seen);
+    }
+  }
+
+  ordvec_t ordinals;
+  for (uint32 ord : seen) ordinals.push_back(ord);
+
+  idalib_string_sink_t sink;
+  const ordvec_t *ordp = ordinals.empty() ? nullptr : &ordinals;
+  int result = print_decls(sink, get_idati(), ordp, flags);
   if (result == 0) {
     throw std::runtime_error("print_decls failed");
   }

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
             let name = func.name().unwrap_or_default();
 
             if let Ok(cfunc) = idb.decompile(&func) {
-                let types = idb.format_func_decls(&cfunc, opts)?;
+                let types = idb.format_cfunc_decls(&cfunc, opts)?;
                 println!("=== types for {name} ===\n{types}");
             }
         }

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -1,0 +1,11 @@
+use idalib::idb::IDB;
+use idalib::typeinf::PrintDeclsFlags;
+
+fn main() -> anyhow::Result<()> {
+    let idb = IDB::open("./tests/ls")?;
+
+    let decls = idb.print_decls(PrintDeclsFlags::INCL_DEPS | PrintDeclsFlags::DEF_FWD)?;
+    println!("{decls}");
+
+    Ok(())
+}

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -4,8 +4,28 @@ use idalib::typeinf::FormatDeclsOptions;
 fn main() -> anyhow::Result<()> {
     let idb = IDB::open("./tests/ls")?;
 
-    let decls = idb.format_decls(FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD)?;
-    println!("{decls}");
+    let opts = FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD;
+
+    // All types in the database.
+    let all = idb.format_decls(opts)?;
+    println!("=== all types ===\n{all}");
+
+    // Types used by the first function, enriched with decompiler locals.
+    if let Some((_, func)) = idb.functions().next() {
+        let name = func.name().unwrap_or_default();
+
+        // Prototype-only (no decompiler needed).
+        let proto_types = idb.format_func_decls(&func, opts)?;
+        println!("=== types for {name} (prototype) ===\n{proto_types}");
+
+        // With decompiler locals.
+        if idb.decompiler_available() {
+            if let Ok(cfunc) = idb.decompile(&func) {
+                let full_types = idb.format_func_decls_with(&func, &cfunc, opts)?;
+                println!("=== types for {name} (with locals) ===\n{full_types}");
+            }
+        }
+    }
 
     Ok(())
 }

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -10,12 +10,13 @@ fn main() -> anyhow::Result<()> {
     let all = idb.format_decls(opts)?;
     println!("=== all types ===\n{all}");
 
+    // Types for each decompiled function.
     if idb.decompiler_available() {
         for (_, func) in idb.functions() {
             let name = func.name().unwrap_or_default();
 
             if let Ok(cfunc) = idb.decompile(&func) {
-                let types = idb.format_func_decls_with(&cfunc, opts)?;
+                let types = idb.format_func_decls(&cfunc, opts)?;
                 println!("=== types for {name} ===\n{types}");
             }
         }

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -10,19 +10,13 @@ fn main() -> anyhow::Result<()> {
     let all = idb.format_decls(opts)?;
     println!("=== all types ===\n{all}");
 
-    // Types used by the first function, enriched with decompiler locals.
-    if let Some((_, func)) = idb.functions().next() {
-        let name = func.name().unwrap_or_default();
+    if idb.decompiler_available() {
+        for (_, func) in idb.functions() {
+            let name = func.name().unwrap_or_default();
 
-        // Prototype-only (no decompiler needed).
-        let proto_types = idb.format_func_decls(&func, opts)?;
-        println!("=== types for {name} (prototype) ===\n{proto_types}");
-
-        // With decompiler locals.
-        if idb.decompiler_available() {
             if let Ok(cfunc) = idb.decompile(&func) {
-                let full_types = idb.format_func_decls_with(&func, &cfunc, opts)?;
-                println!("=== types for {name} (with locals) ===\n{full_types}");
+                let types = idb.format_func_decls_with(&cfunc, opts)?;
+                println!("=== types for {name} ===\n{types}");
             }
         }
     }

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -1,10 +1,10 @@
 use idalib::idb::IDB;
-use idalib::typeinf::PrintDeclsFlags;
+use idalib::typeinf::FormatDeclsOptions;
 
 fn main() -> anyhow::Result<()> {
     let idb = IDB::open("./tests/ls")?;
 
-    let decls = idb.print_decls(PrintDeclsFlags::INCL_DEPS | PrintDeclsFlags::DEF_FWD)?;
+    let decls = idb.format_decls(FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD)?;
     println!("{decls}");
 
     Ok(())

--- a/idalib/examples/types_ls.rs
+++ b/idalib/examples/types_ls.rs
@@ -1,13 +1,10 @@
 use idalib::idb::IDB;
-use idalib::typeinf::FormatDeclsOptions;
 
 fn main() -> anyhow::Result<()> {
     let idb = IDB::open("./tests/ls")?;
 
-    let opts = FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD;
-
     // All types in the database.
-    let all = idb.format_decls(opts)?;
+    let all = idb.format_decls()?;
     println!("=== all types ===\n{all}");
 
     // Types for each decompiled function.
@@ -16,7 +13,7 @@ fn main() -> anyhow::Result<()> {
             let name = func.name().unwrap_or_default();
 
             if let Ok(cfunc) = idb.decompile(&func) {
-                let types = idb.format_cfunc_decls(&cfunc, opts)?;
+                let types = idb.format_cfunc_decls(&cfunc)?;
                 println!("=== types for {name} ===\n{types}");
             }
         }

--- a/idalib/src/decompiler.rs
+++ b/idalib/src/decompiler.rs
@@ -67,6 +67,10 @@ impl<'a> CFunction<'a> {
         unsafe { idalib_hexrays_cfunc_pseudocode(self.ptr) }
     }
 
+    pub(crate) fn as_ptr(&self) -> *mut cfunc_t {
+        self.ptr
+    }
+
     fn as_cfunc(&self) -> &cfunc_t {
         unsafe { self.ptr.as_ref().expect("valid pointer") }
     }

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
+use crate::bookmarks::Bookmarks;
+use crate::decompiler::CFunction;
 use crate::ffi::BADADDR;
 use crate::ffi::bytes::*;
 use crate::ffi::comments::{append_cmt, idalib_get_cmt, set_cmt};
@@ -20,12 +22,9 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
-use crate::ffi::typeinf::{idalib_format_decls, idalib_format_func_type_info};
+use crate::ffi::typeinf::{idalib_format_decls, idalib_format_func_decls};
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
-
-use crate::bookmarks::Bookmarks;
-use crate::decompiler::CFunction;
 use crate::func::{Function, FunctionId};
 use crate::insn::{Insn, Register};
 use crate::meta::{Metadata, MetadataMut};
@@ -170,13 +169,12 @@ impl IDB {
         unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
     }
 
-    pub fn format_func_decls_with<'a>(
+    pub fn format_func_decls<'a>(
         &'a self,
         cfunc: &CFunction<'a>,
         options: FormatDeclsOptions,
     ) -> Result<String, IDAError> {
-        unsafe { idalib_format_func_type_info(cfunc.as_ptr(), options.bits()) }
-            .map_err(IDAError::ffi)
+        unsafe { idalib_format_func_decls(cfunc.as_ptr(), options.bits()) }.map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
+use crate::bookmarks::Bookmarks;
+use crate::decompiler::CFunction;
 use crate::ffi::BADADDR;
 use crate::ffi::bytes::*;
 use crate::ffi::comments::{append_cmt, idalib_get_cmt, set_cmt};
@@ -23,9 +25,6 @@ use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
 use crate::ffi::typeinf::{idalib_format_cfunc_decls, idalib_format_decls};
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
-
-use crate::bookmarks::Bookmarks;
-use crate::decompiler::CFunction;
 use crate::func::{Function, FunctionId};
 use crate::insn::{Insn, Register};
 use crate::meta::{Metadata, MetadataMut};
@@ -166,11 +165,26 @@ impl IDB {
         make_signatures(only_pat)
     }
 
-    pub fn format_decls(&self, options: FormatDeclsOptions) -> Result<String, IDAError> {
+    pub fn format_decls(&self) -> Result<String, IDAError> {
+        // Using both `INCL_DEPS | DEF_FWD` together is the safe combination: `INCL_DEPS` pulls in full definitions
+        // for everything reachable by value, and `DEF_FWD` covers anything only reachable through a pointer.
+        self.format_decls_with(FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD)
+    }
+
+    pub fn format_decls_with(&self, options: FormatDeclsOptions) -> Result<String, IDAError> {
         unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
     }
 
-    pub fn format_cfunc_decls<'a>(
+    pub fn format_cfunc_decls<'a>(&'a self, cfunc: &CFunction<'a>) -> Result<String, IDAError> {
+        // Using both `INCL_DEPS | DEF_FWD` together is the safe combination: `INCL_DEPS` pulls in full definitions
+        // for everything reachable by value, and `DEF_FWD` covers anything only reachable through a pointer.
+        self.format_cfunc_decls_with(
+            cfunc,
+            FormatDeclsOptions::INCL_DEPS | FormatDeclsOptions::DEF_FWD,
+        )
+    }
+
+    pub fn format_cfunc_decls_with<'a>(
         &'a self,
         cfunc: &CFunction<'a>,
         options: FormatDeclsOptions,

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -20,6 +20,7 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
+use crate::ffi::typeinf::idalib_print_decls;
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
 
@@ -33,6 +34,7 @@ use crate::plugin::Plugin;
 use crate::processor::Processor;
 use crate::segment::{Segment, SegmentId};
 use crate::strings::StringList;
+use crate::typeinf::PrintDeclsFlags;
 use crate::xref::{XRef, XRefQuery};
 use crate::{Address, AddressFlags, IDAError, IDARuntimeHandle, prepare_library};
 
@@ -162,6 +164,11 @@ impl IDB {
 
     pub fn make_signatures(&mut self, only_pat: bool) -> Result<(), IDAError> {
         make_signatures(only_pat)
+    }
+
+    pub fn print_decls(&self, flags: PrintDeclsFlags) -> Result<String, IDAError> {
+        unsafe { idalib_print_decls(flags.bits()) }
+            .map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -20,7 +20,7 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
-use crate::ffi::typeinf::idalib_format_decls;
+use crate::ffi::typeinf::{idalib_format_decls, idalib_format_func_type_info};
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
 
@@ -168,6 +168,37 @@ impl IDB {
 
     pub fn format_decls(&self, options: FormatDeclsOptions) -> Result<String, IDAError> {
         unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
+    }
+
+    pub fn format_func_decls(
+        &self,
+        func: &Function<'_>,
+        options: FormatDeclsOptions,
+    ) -> Result<String, IDAError> {
+        unsafe {
+            idalib_format_func_type_info(
+                func.start_address().into(),
+                std::ptr::null_mut(),
+                options.bits(),
+            )
+        }
+        .map_err(IDAError::ffi)
+    }
+
+    pub fn format_func_decls_with<'a>(
+        &'a self,
+        func: &Function<'a>,
+        cfunc: &CFunction<'a>,
+        options: FormatDeclsOptions,
+    ) -> Result<String, IDAError> {
+        unsafe {
+            idalib_format_func_type_info(
+                func.start_address().into(),
+                cfunc.as_ptr(),
+                options.bits(),
+            )
+        }
+        .map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -22,7 +22,7 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
-use crate::ffi::typeinf::{idalib_format_decls, idalib_format_func_decls};
+use crate::ffi::typeinf::{idalib_format_cfunc_decls, idalib_format_decls};
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
 use crate::func::{Function, FunctionId};
@@ -169,12 +169,12 @@ impl IDB {
         unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
     }
 
-    pub fn format_func_decls<'a>(
+    pub fn format_cfunc_decls<'a>(
         &'a self,
         cfunc: &CFunction<'a>,
         options: FormatDeclsOptions,
     ) -> Result<String, IDAError> {
-        unsafe { idalib_format_func_decls(cfunc.as_ptr(), options.bits()) }.map_err(IDAError::ffi)
+        unsafe { idalib_format_cfunc_decls(cfunc.as_ptr(), options.bits()) }.map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -170,35 +170,13 @@ impl IDB {
         unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
     }
 
-    pub fn format_func_decls(
-        &self,
-        func: &Function<'_>,
-        options: FormatDeclsOptions,
-    ) -> Result<String, IDAError> {
-        unsafe {
-            idalib_format_func_type_info(
-                func.start_address().into(),
-                std::ptr::null_mut(),
-                options.bits(),
-            )
-        }
-        .map_err(IDAError::ffi)
-    }
-
     pub fn format_func_decls_with<'a>(
         &'a self,
-        func: &Function<'a>,
         cfunc: &CFunction<'a>,
         options: FormatDeclsOptions,
     ) -> Result<String, IDAError> {
-        unsafe {
-            idalib_format_func_type_info(
-                func.start_address().into(),
-                cfunc.as_ptr(),
-                options.bits(),
-            )
-        }
-        .map_err(IDAError::ffi)
+        unsafe { idalib_format_func_type_info(cfunc.as_ptr(), options.bits()) }
+            .map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -3,8 +3,6 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 
-use crate::bookmarks::Bookmarks;
-use crate::decompiler::CFunction;
 use crate::ffi::BADADDR;
 use crate::ffi::bytes::*;
 use crate::ffi::comments::{append_cmt, idalib_get_cmt, set_cmt};
@@ -25,6 +23,9 @@ use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
 use crate::ffi::typeinf::{idalib_format_cfunc_decls, idalib_format_decls};
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
+
+use crate::bookmarks::Bookmarks;
+use crate::decompiler::CFunction;
 use crate::func::{Function, FunctionId};
 use crate::insn::{Insn, Register};
 use crate::meta::{Metadata, MetadataMut};

--- a/idalib/src/idb.rs
+++ b/idalib/src/idb.rs
@@ -20,7 +20,7 @@ use crate::ffi::loader::find_plugin;
 use crate::ffi::processor::get_ph;
 use crate::ffi::search::{idalib_find_defined, idalib_find_imm, idalib_find_text};
 use crate::ffi::segment::{get_segm_by_name, get_segm_qty, getnseg, getseg};
-use crate::ffi::typeinf::idalib_print_decls;
+use crate::ffi::typeinf::idalib_format_decls;
 use crate::ffi::util::{is_align_insn, next_head, prev_head, str2reg};
 use crate::ffi::xref::{xrefblk_t, xrefblk_t_first_from, xrefblk_t_first_to};
 
@@ -34,7 +34,7 @@ use crate::plugin::Plugin;
 use crate::processor::Processor;
 use crate::segment::{Segment, SegmentId};
 use crate::strings::StringList;
-use crate::typeinf::PrintDeclsFlags;
+use crate::typeinf::FormatDeclsOptions;
 use crate::xref::{XRef, XRefQuery};
 use crate::{Address, AddressFlags, IDAError, IDARuntimeHandle, prepare_library};
 
@@ -166,9 +166,8 @@ impl IDB {
         make_signatures(only_pat)
     }
 
-    pub fn print_decls(&self, flags: PrintDeclsFlags) -> Result<String, IDAError> {
-        unsafe { idalib_print_decls(flags.bits()) }
-            .map_err(IDAError::ffi)
+    pub fn format_decls(&self, options: FormatDeclsOptions) -> Result<String, IDAError> {
+        unsafe { idalib_format_decls(options.bits()) }.map_err(IDAError::ffi)
     }
 
     pub fn decompiler_available(&self) -> bool {

--- a/idalib/src/lib.rs
+++ b/idalib/src/lib.rs
@@ -89,6 +89,7 @@ pub mod plugin;
 pub mod processor;
 pub mod segment;
 pub mod strings;
+pub mod typeinf;
 pub mod xref;
 
 pub use idalib_sys as ffi;

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -8,8 +8,8 @@ bitflags! {
     ///
     /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
     ///
-    /// [`IDB::format_decls`]: crate::idb::IDB::format_decls_with
-    /// [`IDB::format_cfunc_decls`]: crate::idb::IDB::format_cfunc_decls_with
+    /// [`IDB::format_decls_with`]: crate::idb::IDB::format_decls_with
+    /// [`IDB::format_cfunc_decls_with`]: crate::idb::IDB::format_cfunc_decls_with
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct FormatDeclsOptions: u32 {
         /// Include all type dependencies.

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -3,12 +3,13 @@ use bitflags::bitflags;
 use crate::ffi::typeinf::*;
 
 bitflags! {
-    /// Flags controlling how type declarations are extracted by [`IDB::format_decls`] and [`IDB::format_cfunc_decls`].
+    /// Flags controlling how type declarations are extracted by [`IDB::format_decls_with`] and
+    /// [`IDB::format_cfunc_decls_with`].
     ///
     /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
     ///
-    /// [`IDB::format_decls`]: crate::idb::IDB::format_decls
-    /// [`IDB::format_cfunc_decls`]: crate::idb::IDB::format_cfunc_decls
+    /// [`IDB::format_decls`]: crate::idb::IDB::format_decls_with
+    /// [`IDB::format_cfunc_decls`]: crate::idb::IDB::format_cfunc_decls_with
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct FormatDeclsOptions: u32 {
         /// Include all type dependencies.

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -3,11 +3,12 @@ use bitflags::bitflags;
 use crate::ffi::typeinf::*;
 
 bitflags! {
-    /// Flags controlling how type declarations are printed by [`IDB::format_decls`].
+    /// Flags controlling how type declarations are extracted by [`IDB::format_decls`] and [`IDB::format_cfunc_decls`].
     ///
     /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
     ///
     /// [`IDB::format_decls`]: crate::idb::IDB::format_decls
+    /// [`IDB::format_cfunc_decls`]: crate::idb::IDB::format_cfunc_decls
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct FormatDeclsOptions: u32 {
         /// Include all type dependencies.

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -1,0 +1,22 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Flags controlling how type declarations are printed by [`IDB::print_decls`].
+    ///
+    /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
+    ///
+    /// [`IDB::print_decls`]: crate::idb::IDB::print_decls
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct PrintDeclsFlags: u32 {
+        /// Include all type dependencies.
+        const INCL_DEPS    = 0x01;
+        /// Allow forward declarations.
+        const DEF_FWD      = 0x02;
+        /// Include base types: `__int8`, `__int16`, etc.
+        const DEF_BASE     = 0x04;
+        /// Prepend output with a descriptive comment.
+        const HEADER_CMT   = 0x08;
+        /// Ignore types with anonymous names.
+        const NO_ANON_NAME = 0x10;
+    }
+}

--- a/idalib/src/typeinf.rs
+++ b/idalib/src/typeinf.rs
@@ -1,22 +1,24 @@
 use bitflags::bitflags;
 
+use crate::ffi::typeinf::*;
+
 bitflags! {
-    /// Flags controlling how type declarations are printed by [`IDB::print_decls`].
+    /// Flags controlling how type declarations are printed by [`IDB::format_decls`].
     ///
     /// These correspond to the `PDF_*` constants in the IDA SDK's `typeinf.hpp`.
     ///
-    /// [`IDB::print_decls`]: crate::idb::IDB::print_decls
+    /// [`IDB::format_decls`]: crate::idb::IDB::format_decls
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct PrintDeclsFlags: u32 {
+    pub struct FormatDeclsOptions: u32 {
         /// Include all type dependencies.
-        const INCL_DEPS    = 0x01;
+        const INCL_DEPS = PDF_INCL_DEPS as _;
         /// Allow forward declarations.
-        const DEF_FWD      = 0x02;
+        const DEF_FWD = PDF_DEF_FWD as _;
         /// Include base types: `__int8`, `__int16`, etc.
-        const DEF_BASE     = 0x04;
+        const DEF_BASE = PDF_DEF_BASE as _;
         /// Prepend output with a descriptive comment.
-        const HEADER_CMT   = 0x08;
+        const HEADER_CMT = PDF_HEADER_CMT as _;
         /// Ignore types with anonymous names.
-        const NO_ANON_NAME = 0x10;
+        const NO_ANON_NAME = PDF_NO_ANON_NAME as _;
     }
 }


### PR DESCRIPTION
This is an improved version of https://github.com/idalib-rs/idalib/pull/67 that adds the capability to dump types per-function, to better accommodate the needs expressed by @bukowa in its https://github.com/0xdea/haruspex/issues/3.