### PR TITLE
fix: update license_manager_t_vtbl structure for compatibility with IDA 9.4

### DIFF
--- a/idalib-sys/src/kernwin_extras.h
+++ b/idalib-sys/src/kernwin_extras.h
@@ -60,7 +60,7 @@ struct license_manager_t_vtbl {
   int (*get_or_borrow_license)(license_manager_t *, void *, license_info_t *,
                                uint64_t, qstring *);
   void *(*get_license_location)(license_manager_t *);
-  void *_skip_b[5];
+  void *_skip_b[6];
   license_result_t *(*check)(license_manager_t *, bool *, int);
 };
 


### PR DESCRIPTION
The structure defined in `idalib` as `license_manager_t_vtbl` has been updated in IDA 9.4 Beta 1. This change has been tested on `armmac`, `x64linux` and `x64win` installations.